### PR TITLE
Implement form saving to .wdoc

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,8 @@
 <div class="container">
-  <app-navbar (fileSelected)="onFileSelected($event)"></app-navbar>
+  <app-navbar
+    (fileSelected)="onFileSelected($event)"
+    [showSave]="showSave"
+    (save)="onSaveForms()"
+  ></app-navbar>
   <app-viewer [htmlContent]="htmlContent"></app-viewer>
 </div>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -39,4 +39,16 @@ describe('AppComponent', () => {
     expect(result).not.toContain('<iframe');
     expect(result).toContain('ok');
   });
+
+  it('should mark showSave when form input changes', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+    const input = document.createElement('input');
+    const container = document.createElement('div');
+    container.appendChild(input);
+    app.viewer = { nativeElement: container } as any;
+    (app as any).attachFormListeners();
+    input.dispatchEvent(new Event('input'));
+    expect(app.showSave).toBeTrue();
+  });
 });

--- a/src/app/navbar.component.css
+++ b/src/app/navbar.component.css
@@ -13,3 +13,7 @@ nav .title {
 nav input {
   color: #fff;
 }
+
+nav button {
+  margin-left: auto;
+}

--- a/src/app/navbar.component.html
+++ b/src/app/navbar.component.html
@@ -1,4 +1,5 @@
 <nav>
   <div class="title">WDOC viewer</div>
   <input type="file" (change)="onFileChange($event)" accept=".wdoc" />
+  <button *ngIf="showSave" (click)="onSave()">Save</button>
 </nav>

--- a/src/app/navbar.component.spec.ts
+++ b/src/app/navbar.component.spec.ts
@@ -29,4 +29,16 @@ describe('NavbarComponent', () => {
     expect(emitted).toBeTruthy();
     expect(emitted!.name).toBe('test.wdoc');
   });
+
+  it('should emit save event', () => {
+    component.showSave = true;
+    fixture.detectChanges();
+    let called = false;
+    component.save.subscribe(() => (called = true));
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(called).toBeTrue();
+  });
 });

--- a/src/app/navbar.component.ts
+++ b/src/app/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Output, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -10,11 +10,17 @@ import { CommonModule } from '@angular/common';
 })
 export class NavbarComponent {
   @Output() fileSelected = new EventEmitter<File>();
+  @Output() save = new EventEmitter<void>();
+  @Input() showSave = false;
 
   onFileChange(event: Event) {
     const input = event.target as HTMLInputElement;
     if (input.files && input.files.length > 0) {
       this.fileSelected.emit(input.files[0]);
     }
+  }
+
+  onSave() {
+    this.save.emit();
   }
 }

--- a/src/app/viewer.component.ts
+++ b/src/app/viewer.component.ts
@@ -16,4 +16,8 @@ export class ViewerComponent implements AfterViewInit {
   ngAfterViewInit() {
     // scaling or other operations could go here
   }
+
+  get nativeElement(): HTMLElement {
+    return this.contentContainer.nativeElement as HTMLElement;
+  }
 }


### PR DESCRIPTION
## Summary
- show a Save button in the navbar when a form is modified
- emit an event when Save is clicked
- collect form data and package it in a `wdoc-form` directory
- download a new `.wdoc` file with the original content and saved form JSON
- add unit tests for new navbar and form logic

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_68582616d1e4832ba2f24fb828432c18