### PR TITLE
Validate .wdoc files against content manifests

### DIFF
--- a/e2e/wdoc.examples.spec.ts
+++ b/e2e/wdoc.examples.spec.ts
@@ -50,3 +50,12 @@ test('form example displays form', async ({ page }) => {
   await loadExample(page, 'form');
   await expect(page.locator('form')).toHaveCount(1);
 });
+
+test('image_changed example warns about signature mismatch', async ({ page }) => {
+  const dialogPromise = page.waitForEvent('dialog');
+  await loadExample(page, 'image_changed');
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toContain('does not match its manifest');
+  await dialog.dismiss();
+  await expect(page.locator('wdoc-container')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- validate .wdoc archives against their content manifest before loading them
- add unit coverage for successful and failing manifest verification flows
- extend the Playwright e2e suite with the tampered image regression test

## Testing
- CHROME_BIN=chromium npm test -- --watch=false --progress=false *(fails: ChromeHeadless missing libatk-1.0.so.0 on host)*
- npx playwright test e2e/wdoc.examples.spec.ts *(fails: host system missing required browser dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910b9dac0d8832bb9db12402b666c3d)