### PR TITLE
Handle nested index file in wdoc archives

### DIFF
--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -33,7 +33,22 @@ export class AppComponent {
             return;
           }
           this.originalArrayBuffer = arrayBuffer;
-          const indexFile = zip.file('index.html');
+          let indexFile = zip.file('index.html');
+          if (!indexFile) {
+            const firstFolder = Object.keys(zip.files)
+              .filter((path) => {
+                const entry = zip.files[path];
+                return (
+                  entry.dir &&
+                  path.endsWith('/') &&
+                  !path.slice(0, -1).includes('/')
+                );
+              })
+              .sort()[0];
+            if (firstFolder) {
+              indexFile = zip.file(`${firstFolder}index.html`);
+            }
+          }
           if (!indexFile) {
             alert('index.html not found in the .wdoc file.');
             return;


### PR DESCRIPTION
## Summary
- look for a top-level folder when index.html is missing from the root of a .wdoc
- load index.html from that folder so archives zipped as directories still render

## Testing
- npx ng test --watch=false --browsers=ChromeHeadless --progress=false *(fails: ChromeHeadless missing system dependency libatk-1.0.so.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910dc8efd30832b81d134d7b3a457a5)