### PR TITLE
Improve print layout for paginated documents

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -17,3 +17,9 @@ nav input {
 nav button {
   margin-left: auto;
 }
+
+@media print {
+  :host {
+    display: none !important;
+  }
+}

--- a/src/assets/wdoc-styles.css
+++ b/src/assets/wdoc-styles.css
@@ -27,3 +27,36 @@ wdoc-page {
     align-items: flex-start;
   }
 }
+
+@page {
+  size: A4;
+  margin: 10mm;
+}
+
+@media print {
+  body,
+  html {
+    background: transparent !important;
+  }
+
+  wdoc-container {
+    background: transparent;
+    padding: 0;
+    height: auto;
+    overflow: visible;
+    display: block;
+  }
+
+  wdoc-page {
+    width: 793.8px;
+    min-height: 1122px;
+    box-shadow: none;
+    margin: 0 auto;
+    page-break-after: always;
+    page-break-inside: avoid;
+  }
+
+  wdoc-page:last-child {
+    page-break-after: auto;
+  }
+}

--- a/src/assets/wdoc-styles.css
+++ b/src/assets/wdoc-styles.css
@@ -20,6 +20,7 @@ wdoc-page {
   padding: 20px;
   box-sizing: border-box;
   margin-bottom: 20px;
+  display: block;
 }
 
 @media (max-width: 840px) {
@@ -30,7 +31,7 @@ wdoc-page {
 
 @page {
   size: A4;
-  margin: 10mm;
+  margin: 0;
 }
 
 @media print {
@@ -48,15 +49,19 @@ wdoc-page {
   }
 
   wdoc-page {
-    width: 793.8px;
+    width: 100%;
+    max-width: 793.8px;
     min-height: 1122px;
     box-shadow: none;
     margin: 0 auto;
     page-break-after: always;
     page-break-inside: avoid;
+    break-after: page;
+    break-inside: avoid;
   }
 
   wdoc-page:last-child {
     page-break-after: auto;
+    break-after: auto;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,3 +3,9 @@ body {
   padding: 0;
   overflow: hidden;
 }
+
+@media print {
+  body {
+    overflow: visible;
+  }
+}


### PR DESCRIPTION
## Summary
- adjust global body overflow for print-only scenarios so printed pages are not clipped
- add print-specific styling for wdoc containers and pages to preserve pagination and remove on-screen chrome

## Testing
- npm test -- --watch=false --progress=false *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910dff341b8832baa79ce41f06a6b4f)