### PR TITLE
Extract topbar into standalone component

### DIFF
--- a/src/app/app/app.component.css
+++ b/src/app/app/app.component.css
@@ -1,4 +1,36 @@
-.container {
-  margin: 0 auto;
-  padding: 0;
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: #0f0f0f;
+}
+
+.main-content {
+  flex: 1;
+  margin-left: 0;
+  min-height: 100vh;
+  background: #f5f5f5;
+  transition: margin-left 0.25s ease-out;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell.nav-open .main-content {
+  margin-left: 280px;
+}
+
+app-viewer {
+  flex: 1;
+  overflow: auto;
+}
+
+@media (max-width: 991px) {
+  .app-shell.nav-open .main-content {
+    margin-left: 0;
+  }
+}
+
+@media print {
+  .main-content {
+    margin-left: 0 !important;
+  }
 }

--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -1,8 +1,19 @@
-<div class="container">
+<div class="app-shell" [class.nav-open]="isNavOpen">
   <app-navbar
     (fileSelected)="onFileSelected($event)"
     [showSave]="showSave"
     (save)="onSaveForms()"
+    [open]="isNavOpen"
+    (closeNav)="closeNav()"
   ></app-navbar>
-  <app-viewer [htmlContent]="htmlContent"></app-viewer>
+
+  <div class="main-content">
+    <app-topbar
+      [showSave]="showSave"
+      [navOpen]="isNavOpen"
+      (toggleNav)="toggleNav()"
+      (save)="onSaveForms()"
+    ></app-topbar>
+    <app-viewer [htmlContent]="htmlContent"></app-viewer>
+  </div>
 </div>

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -1,27 +1,33 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { HttpClient } from '@angular/common/http';
 import { lastValueFrom } from 'rxjs';
 import JSZip from 'jszip';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { ViewerComponent } from '../viewer/viewer.component';
+import { TopbarComponent } from '../topbar/topbar.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [NavbarComponent, ViewerComponent],
+  imports: [CommonModule, NavbarComponent, ViewerComponent, TopbarComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent implements OnInit {
   htmlContent: SafeHtml | null = null;
   showSave = false;
+  isNavOpen = false;
   private originalArrayBuffer: ArrayBuffer | null = null;
   @ViewChild(ViewerComponent) viewer!: ViewerComponent;
 
   constructor(private sanitizer: DomSanitizer, private http: HttpClient) {}
 
   ngOnInit(): void {
+    if (typeof window !== 'undefined') {
+      this.isNavOpen = window.innerWidth >= 992;
+    }
     if (typeof window === 'undefined' || !window.location) {
       return;
     }
@@ -49,6 +55,14 @@ export class AppComponent implements OnInit {
       }
     };
     reader.readAsArrayBuffer(file);
+  }
+
+  toggleNav() {
+    this.isNavOpen = !this.isNavOpen;
+  }
+
+  closeNav() {
+    this.isNavOpen = false;
   }
 
   private async fetchAndLoadWdoc(url: string): Promise<void> {

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -1,21 +1,107 @@
-nav {
+.sidenav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 280px;
+  background-color: #1f1f1f;
+  color: #fff;
+  transform: translateX(-100%);
+  transition: transform 0.25s ease-out;
+  z-index: 1000;
   display: flex;
-  padding: 10px;
-  background-color: #333;
-  height: 41px;
+  flex-direction: column;
+  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.4);
 }
 
-nav .title {
+.sidenav.sidenav-open {
+  transform: translateX(0);
+}
+
+.sidenav-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.nav-content {
+  padding: 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+
+.nav-btn {
+  background-color: #fff;
+  color: #1f1f1f;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.nav-btn:focus-visible,
+.save-btn:focus-visible {
+  outline: 2px solid #76c7ff;
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.save-btn {
+  background-color: #4caf50;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
   color: #fff;
-  margin-right: 10px;
+  font-weight: 600;
 }
 
-nav input {
-  color: #fff;
+.sidenav-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 900;
 }
 
-nav button {
-  margin-left: auto;
+@media (min-width: 992px) {
+  .sidenav {
+    position: relative;
+    transform: translateX(0);
+    height: 100%;
+  }
+
+  .sidenav-backdrop {
+    display: none;
+  }
 }
 
 @media print {

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,5 +1,26 @@
-<nav>
-  <div class="title">WDOC viewer</div>
-  <input type="file" (change)="onFileChange($event)" accept=".wdoc" />
-  <button *ngIf="showSave" (click)="onSave()">Save</button>
-</nav>
+<div class="sidenav-backdrop" *ngIf="open" (click)="onCloseNav()"></div>
+<aside class="sidenav" [class.sidenav-open]="open" aria-label="Document navigation">
+  <header class="sidenav-header">
+    <div class="title">Navigation</div>
+    <button class="close-btn" (click)="onCloseNav()" aria-label="Close navigation">
+      &times;
+    </button>
+  </header>
+  <div class="nav-content">
+    <button type="button" class="nav-btn" (click)="triggerFileDialog()">
+      Open .wdoc file
+    </button>
+    <input
+      #fileInput
+      type="file"
+      class="sr-only"
+      (change)="onFileChange($event)"
+      accept=".wdoc"
+      aria-hidden="true"
+      tabindex="-1"
+    />
+    <button *ngIf="showSave" (click)="onSave()" class="save-btn">
+      Save form data
+    </button>
+  </div>
+</aside>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -1,8 +1,16 @@
 <div class="sidenav-backdrop" *ngIf="open" (click)="onCloseNav()"></div>
-<aside class="sidenav" [class.sidenav-open]="open" aria-label="Document navigation">
+<aside
+  class="sidenav"
+  [class.sidenav-open]="open"
+  aria-label="Document navigation"
+>
   <header class="sidenav-header">
     <div class="title">Navigation</div>
-    <button class="close-btn" (click)="onCloseNav()" aria-label="Close navigation">
+    <button
+      class="close-btn"
+      (click)="onCloseNav()"
+      aria-label="Close navigation"
+    >
       &times;
     </button>
   </header>
@@ -19,8 +27,5 @@
       aria-hidden="true"
       tabindex="-1"
     />
-    <button *ngIf="showSave" (click)="onSave()" class="save-btn">
-      Save form data
-    </button>
   </div>
 </aside>

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -29,18 +29,4 @@ describe('NavbarComponent', () => {
     expect(emitted).toBeTruthy();
     expect(emitted!.name).toBe('test.wdoc');
   });
-
-  it('should emit save event', () => {
-    component.showSave = true;
-    fixture.detectChanges();
-    let called = false;
-    component.save.subscribe(() => (called = true));
-
-    const button = fixture.nativeElement.querySelector(
-      '.save-btn'
-    ) as HTMLButtonElement;
-    button.click();
-
-    expect(called).toBeTrue();
-  });
 });

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -36,7 +36,9 @@ describe('NavbarComponent', () => {
     let called = false;
     component.save.subscribe(() => (called = true));
 
-    const button = fixture.nativeElement.querySelector('button');
+    const button = fixture.nativeElement.querySelector(
+      '.save-btn'
+    ) as HTMLButtonElement;
     button.click();
 
     expect(called).toBeTrue();

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -1,4 +1,11 @@
-import { Component, ElementRef, EventEmitter, Output, Input, ViewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Output,
+  Input,
+  ViewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -25,10 +32,6 @@ export class NavbarComponent {
 
   triggerFileDialog() {
     this.fileInput?.nativeElement.click();
-  }
-
-  onSave() {
-    this.save.emit();
   }
 
   onCloseNav() {

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Output, Input, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -12,6 +12,9 @@ export class NavbarComponent {
   @Output() fileSelected = new EventEmitter<File>();
   @Output() save = new EventEmitter<void>();
   @Input() showSave = false;
+  @Input() open = false;
+  @Output() closeNav = new EventEmitter<void>();
+  @ViewChild('fileInput') fileInput?: ElementRef<HTMLInputElement>;
 
   onFileChange(event: Event) {
     const input = event.target as HTMLInputElement;
@@ -20,7 +23,15 @@ export class NavbarComponent {
     }
   }
 
+  triggerFileDialog() {
+    this.fileInput?.nativeElement.click();
+  }
+
   onSave() {
     this.save.emit();
+  }
+
+  onCloseNav() {
+    this.closeNav.emit();
   }
 }

--- a/src/app/topbar/topbar.component.css
+++ b/src/app/topbar/topbar.component.css
@@ -1,0 +1,51 @@
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: #ffffff;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.hamburger {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: #f0f0f0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.hamburger span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: #333;
+}
+
+.topbar-title {
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.topbar-save {
+  margin-left: auto;
+  background-color: #4caf50;
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+@media print {
+  :host {
+    display: none !important;
+  }
+}

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -1,0 +1,17 @@
+<header class="topbar">
+  <button
+    type="button"
+    class="hamburger"
+    (click)="onToggleNav()"
+    aria-label="Toggle navigation"
+    [attr.aria-expanded]="navOpen"
+  >
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
+  <div class="topbar-title">WDOC viewer</div>
+  <button *ngIf="showSave" class="topbar-save" type="button" (click)="onSave()">
+    Save
+  </button>
+</header>

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -11,7 +11,12 @@
     <span></span>
   </button>
   <div class="topbar-title">WDOC viewer</div>
-  <button *ngIf="showSave" class="topbar-save" type="button" (click)="onSave()">
+  <button
+    class="topbar-save"
+    type="button"
+    (click)="onSave()"
+    [hidden]="!showSave"
+  >
     Save
   </button>
 </header>

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TopbarComponent } from './topbar.component';
+
+describe('TopbarComponent', () => {
+  let component: TopbarComponent;
+  let fixture: ComponentFixture<TopbarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TopbarComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TopbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('emits toggle event when hamburger clicked', () => {
+    spyOn(component.toggleNav, 'emit');
+    const btn = fixture.nativeElement.querySelector('.hamburger');
+    btn.click();
+    expect(component.toggleNav.emit).toHaveBeenCalled();
+  });
+
+  it('emits save when save button clicked', () => {
+    component.showSave = true;
+    fixture.detectChanges();
+    spyOn(component.save, 'emit');
+    const btn = fixture.nativeElement.querySelector('.topbar-save');
+    btn.click();
+    expect(component.save.emit).toHaveBeenCalled();
+  });
+});

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -1,0 +1,24 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-topbar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './topbar.component.html',
+  styleUrls: ['./topbar.component.css'],
+})
+export class TopbarComponent {
+  @Input() showSave = false;
+  @Input() navOpen = false;
+  @Output() toggleNav = new EventEmitter<void>();
+  @Output() save = new EventEmitter<void>();
+
+  onToggleNav() {
+    this.toggleNav.emit();
+  }
+
+  onSave() {
+    this.save.emit();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a standalone `TopbarComponent` that encapsulates the hamburger toggle, title, and conditional save button styling/logic
- swap the inline header in `AppComponent` for the new component and keep the surrounding layout styles scoped to the shell
- cover the new component with simple event-emission unit tests

## Testing
- `npm test -- --watch=false --progress=false`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b7707011c832bb185791f78cd6799)