### PR TITLE
Prevent printed pages from centering headings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wdocviewer",
+  "name": "wdoc-webapp",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wdocviewer",
+      "name": "wdoc-webapp",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^20.3.12",

--- a/src/app/app/app.component.css
+++ b/src/app/app/app.component.css
@@ -39,6 +39,18 @@ app-viewer {
     overflow: visible !important;
   }
 
+  mat-sidenav-container {
+    display: block !important;
+    width: auto !important;
+  }
+
+  mat-sidenav-content,
+  .mat-drawer-content {
+    margin: 0 !important;
+    transform: none !important;
+    left: 0 !important;
+  }
+
   app-viewer {
     flex: initial;
   }

--- a/src/app/app/app.component.css
+++ b/src/app/app/app.component.css
@@ -27,6 +27,22 @@ app-viewer {
 }
 
 @media print {
+  :host,
+  .app-shell,
+  mat-sidenav-container,
+  mat-sidenav-content,
+  .mat-drawer-content,
+  .main-content,
+  app-viewer {
+    height: auto !important;
+    min-height: auto !important;
+    overflow: visible !important;
+  }
+
+  app-viewer {
+    flex: initial;
+  }
+
   .app-sidenav,
   mat-sidenav {
     display: none !important;

--- a/src/assets/wdoc-styles.css
+++ b/src/assets/wdoc-styles.css
@@ -49,11 +49,11 @@ wdoc-page {
   }
 
   wdoc-page {
-    width: 100%;
-    max-width: 793.8px;
+    width: 793.8px;
+    max-width: none;
     min-height: 1122px;
     box-shadow: none;
-    margin: 0 auto;
+    margin: 0;
     page-break-after: always;
     page-break-inside: avoid;
     break-after: page;

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,6 +12,12 @@ body {
 }
 
 @media print {
+  html,
+  body {
+    height: auto;
+    min-height: auto;
+  }
+
   body {
     overflow: visible;
   }


### PR DESCRIPTION
## Summary
- keep printed `wdoc-page` elements at their intrinsic width with no auto margins so their content remains left aligned instead of shifting to the center when exporting

## Testing
- `CI=true npm test -- --watch=false`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691b8e8fa340832bbc9abdb225615b64)