### PR TITLE
feat: paginate raw html with html-pages

### DIFF
--- a/e2e/wdoc.security.spec.ts
+++ b/e2e/wdoc.security.spec.ts
@@ -21,14 +21,17 @@ test('internal_script example strips scripts', async ({ page }) => {
 
 test('internal_image example embeds images', async ({ page }) => {
   await loadExample(page, 'internal_image');
-  const src = await page.locator('img').getAttribute('src');
+  const src = await page.locator('wdoc-page img').getAttribute('src');
   expect(src).toMatch(/^data:image\//);
 });
 
 test('external_image example loads after confirm', async ({ page }) => {
   page.once('dialog', (dialog) => dialog.accept());
   await loadExample(page, 'external_image');
-  await expect(page.locator('img')).toHaveAttribute('src', /logo.png/);
+  await expect(page.locator('wdoc-page img')).toHaveAttribute(
+    'src',
+    /logo.png/
+  );
 });
 
 test('image_changed example warns about signature mismatch', async ({

--- a/e2e/wdoc.security.spec.ts
+++ b/e2e/wdoc.security.spec.ts
@@ -15,7 +15,7 @@ test.beforeEach(async ({ page }) => {
 
 test('internal_script example strips scripts', async ({ page }) => {
   await loadExample(page, 'internal_script');
-  await expect(page.locator('h1')).toHaveText('Internal script');
+  await expect(page.locator('wdoc-container h1')).toHaveText('Internal script');
   await expect(page.locator('wdoc-container script')).toHaveCount(0);
 });
 

--- a/e2e/wdoc.unit_test.spec.ts
+++ b/e2e/wdoc.unit_test.spec.ts
@@ -23,6 +23,11 @@ test('already_paginated keeps pages', async ({ page }) => {
   await expect(page.locator('wdoc-page')).toHaveCount(2);
 });
 
+test('not_paginated creates multiple pages', async ({ page }) => {
+  await loadExample(page, 'not_paginated');
+  await expect(page.locator('wdoc-page')).toHaveCount(2);
+});
+
 test('form example displays form', async ({ page }) => {
   await loadExample(page, 'form');
   await expect(page.locator('wdoc-page form')).toHaveCount(1);

--- a/e2e/wdoc.unit_test.spec.ts
+++ b/e2e/wdoc.unit_test.spec.ts
@@ -15,7 +15,7 @@ test.beforeEach(async ({ page }) => {
 
 test('hello_world example renders', async ({ page }) => {
   await loadExample(page, 'hello_world');
-  await expect(page.locator('h1')).toHaveText('Hello, World!');
+  await expect(page.locator('wdoc-page h1')).toHaveText('Hello, World!');
 });
 
 test('already_paginated keeps pages', async ({ page }) => {
@@ -25,7 +25,7 @@ test('already_paginated keeps pages', async ({ page }) => {
 
 test('form example displays form', async ({ page }) => {
   await loadExample(page, 'form');
-  await expect(page.locator('form')).toHaveCount(1);
+  await expect(page.locator('wdoc-page form')).toHaveCount(1);
 });
 
 test('url query parameter loads remote .wdoc', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4330,9 +4330,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6695,9 +6695,9 @@
       }
     },
     "node_modules/cacache/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser": "^20.3.12",
         "@angular/platform-browser-dynamic": "^20.3.12",
         "@angular/router": "^20.3.12",
+        "@talers/html-pages": "^0.5.5",
         "jszip": "^3.10.1",
         "puppeteer": "^24.30.0",
         "rxjs": "~7.8.0",
@@ -5404,6 +5405,11 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@talers/html-pages": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@talers/html-pages/-/html-pages-0.5.5.tgz",
+      "integrity": "sha512-yIasj9HqO/IN/n+TxyvgMXxMro0Sn6pmIf0AgAhsF/jdpr+dXctiNuv17F0AWxz1iqa2mVh5j7nwREZ4bMFz6A=="
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^20.3.12",
     "@angular/platform-browser-dynamic": "^20.3.12",
     "@angular/router": "^20.3.12",
+    "@talers/html-pages": "^0.5.5",
     "jszip": "^3.10.1",
     "puppeteer": "^24.30.0",
     "rxjs": "~7.8.0",

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -60,6 +60,29 @@ describe('AppComponent', () => {
     expect(doc.querySelectorAll('wdoc-page').length).toBeGreaterThan(0);
   });
 
+  it('splits long documents across multiple pages when needed', async () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    const httpMock = TestBed.inject(HttpTestingController);
+
+    const longBody = Array.from({ length: 200 })
+      .map((_, idx) => `<p>Paragraph ${idx}</p>`)
+      .join('');
+    const html = `<html><head></head><body>${longBody}</body></html>`;
+    const zip = new JSZip();
+
+    const promise = app.processHtml(zip, html);
+    const req = httpMock.expectOne('assets/wdoc-styles.css');
+    req.flush('');
+
+    const result = await promise;
+    httpMock.verify();
+
+    const doc = new DOMParser().parseFromString(result, 'text/html');
+    const pages = doc.querySelectorAll('wdoc-page');
+    expect(pages.length).toBeGreaterThan(1);
+  });
+
   it('should mark showSave when form input changes', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -40,6 +40,26 @@ describe('AppComponent', () => {
     expect(result).toContain('ok');
   });
 
+  it('paginates HTML without wdoc-page elements', async () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    const httpMock = TestBed.inject(HttpTestingController);
+
+    const html = '<html><head></head><body><h1>Doc</h1><p>Content</p></body></html>';
+    const zip = new JSZip();
+
+    const promise = app.processHtml(zip, html);
+    const req = httpMock.expectOne('assets/wdoc-styles.css');
+    req.flush('');
+
+    const result = await promise;
+    httpMock.verify();
+
+    const doc = new DOMParser().parseFromString(result, 'text/html');
+    expect(doc.querySelector('wdoc-container')).toBeTruthy();
+    expect(doc.querySelectorAll('wdoc-page').length).toBeGreaterThan(0);
+  });
+
   it('should mark showSave when form input changes', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -44,6 +44,7 @@ export class AppComponent implements OnInit, OnDestroy {
       if (this.paginationContainer) {
         this.htmlPageSplitter = new HtmlPageSplitter({
           container: this.paginationContainer,
+          pageHeight: 1122,
         });
       }
     }
@@ -457,10 +458,11 @@ export class AppComponent implements OnInit, OnDestroy {
     container.style.top = '0';
     container.style.left = '0';
     container.style.width = '793.8px';
-    container.style.height = '1122px';
     container.style.padding = '20px';
     container.style.boxSizing = 'border-box';
-    container.style.overflow = 'hidden';
+    container.style.minHeight = '1122px';
+    container.style.height = 'auto';
+    container.style.overflow = 'visible';
     container.style.zIndex = '-1';
     document.body.appendChild(container);
     return container;

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -4,6 +4,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { HttpClient } from '@angular/common/http';
 import { lastValueFrom } from 'rxjs';
 import JSZip from 'jszip';
+import { HtmlPageSplitter } from '../pagination/html-pages/HtmlPageSplitter';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { ViewerComponent } from '../viewer/viewer.component';
 import { TopbarComponent } from '../topbar/topbar.component';
@@ -33,9 +34,20 @@ export class AppComponent implements OnInit, OnDestroy {
   private beforePrintListener?: () => void;
   private afterPrintListener?: () => void;
   private wasNavOpenBeforePrint = false;
+  private htmlPageSplitter?: HtmlPageSplitter;
+  private paginationContainer?: HTMLElement;
   @ViewChild(ViewerComponent) viewer!: ViewerComponent;
 
-  constructor(private sanitizer: DomSanitizer, private http: HttpClient) {}
+  constructor(private sanitizer: DomSanitizer, private http: HttpClient) {
+    if (typeof document !== 'undefined') {
+      this.paginationContainer = this.createPaginationContainer();
+      if (this.paginationContainer) {
+        this.htmlPageSplitter = new HtmlPageSplitter({
+          container: this.paginationContainer,
+        });
+      }
+    }
+  }
 
   ngOnInit(): void {
     if (typeof window !== 'undefined') {
@@ -82,6 +94,10 @@ export class AppComponent implements OnInit, OnDestroy {
         window.removeEventListener('afterprint', this.afterPrintListener);
       }
     }
+    if (this.paginationContainer?.parentElement) {
+      this.paginationContainer.remove();
+    }
+    this.htmlPageSplitter?.abort();
   }
 
   onFileSelected(file: File) {
@@ -236,7 +252,6 @@ export class AppComponent implements OnInit, OnDestroy {
 
     // 1. Remove external script tags with a "src" attribute and all iframes.
     const scripts = doc.querySelectorAll('script');
-    console.log('scripts', scripts);
     scripts.forEach((script) => script.remove());
 
     // 2.  Remove all iframe elements
@@ -385,38 +400,70 @@ export class AppComponent implements OnInit, OnDestroy {
    * TODO: doesn t work, the example overflowing_text doesn t display on multiple pages
    */
   private async paginateContent(doc: Document): Promise<void> {
-    const A4PageHeight = 1122; // Approximate A4 height in pixels.
-    const body = doc.body;
-    const nodes = Array.from(body.childNodes);
-    body.innerHTML = '';
+    if (!this.htmlPageSplitter) {
+      console.warn('HtmlPageSplitter is not available; skipping pagination.');
+      return;
+    }
 
-    // Create and attach the page container immediately.
+    const body = doc.body;
+    const contentNodes = Array.from(body.childNodes).filter((node) => {
+      return !(
+        node.nodeType === Node.ELEMENT_NODE &&
+        (node as Element).tagName.toLowerCase() === 'style'
+      );
+    });
+
+    if (contentNodes.length === 0) {
+      return;
+    }
+
+    const wrapper = doc.createElement('div');
+    contentNodes.forEach((node) => {
+      wrapper.appendChild(node.cloneNode(true));
+      node.remove();
+    });
+
     const wdocContainer = doc.createElement('wdoc-container');
     body.appendChild(wdocContainer);
 
-    // Function to create a new page wrapper and page.
-    const createNewPage = (): Element => {
-      const page = doc.createElement('wdoc-page');
-      wdocContainer.appendChild(page);
-      return page;
-    };
-
-    // Create the first page.
-    let currentPage = createNewPage();
-
-    nodes.forEach((node) => {
-      currentPage.appendChild(node);
-      // Force a reflow so the browser updates layout.
-      const height = (currentPage as HTMLElement).offsetHeight;
-      console.log('offsetHeight', height, A4PageHeight);
-
-      // If content exceeds A4 page height, move the node to a new page.
-      if (height > A4PageHeight) {
-        currentPage.removeChild(node);
-        currentPage = createNewPage();
-        currentPage.appendChild(node);
+    let hasPages = false;
+    for await (const pageHtml of this.htmlPageSplitter.split(
+      wrapper.innerHTML
+    )) {
+      const trimmed = pageHtml.trim();
+      if (!trimmed) {
+        continue;
       }
-    });
+      const page = doc.createElement('wdoc-page');
+      page.innerHTML = pageHtml;
+      wdocContainer.appendChild(page);
+      hasPages = true;
+    }
+
+    if (!hasPages) {
+      const emptyPage = doc.createElement('wdoc-page');
+      wdocContainer.appendChild(emptyPage);
+    }
+  }
+
+  private createPaginationContainer(): HTMLElement | undefined {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+    const container = document.createElement('div');
+    container.style.position = 'absolute';
+    container.style.visibility = 'hidden';
+    container.style.pointerEvents = 'none';
+    container.style.top = '0';
+    container.style.left = '0';
+    container.style.width = '793.8px';
+    container.style.height = '1122px';
+    container.style.padding = '20px';
+    container.style.boxSizing = 'border-box';
+    container.style.overflow = 'hidden';
+    container.style.zIndex = '-1';
+    document.body.appendChild(container);
+    return container;
   }
 
   private async populateFormsFromZip(zip: JSZip, doc: Document): Promise<void> {

--- a/src/app/pagination/html-pages/HtmlPageSplitter.ts
+++ b/src/app/pagination/html-pages/HtmlPageSplitter.ts
@@ -1,0 +1,41 @@
+// Derived from @talers/html-pages v0.5.5 (https://www.npmjs.com/package/@talers/html-pages).
+import { splitHtmlToPages } from './splitHtmlToPages';
+import type { HtmlPageSplitterOptions } from './types';
+
+/**
+ * The `HtmlPageSplitter` class is used to split an HTML string into multiple pages.
+ */
+export class HtmlPageSplitter {
+  private controller = new AbortController();
+
+  constructor(public defaultOptions: HtmlPageSplitterOptions = {}) {}
+
+  /**
+   * Start the split process.
+   * This function is an async generator that yields one page at a time.
+   * This allow your first pages to be rendered very fast, even for large workloads.
+   * A good technique is to buffer every 10 pages before rendering them.
+   * @param html - The HTML string to split.
+   * @param options - The options to use for the split (will override the default options).
+   */
+  async *split(
+    html: string,
+    options: HtmlPageSplitterOptions = {},
+  ): AsyncGenerator<string> {
+    for await (const page of splitHtmlToPages(
+      html,
+      { ...this.defaultOptions, ...options },
+      this.controller.signal,
+    )) {
+      yield page;
+    }
+  }
+
+  /**
+   * Abort the split process.
+   * Use this when you started a long process (several thousands of pages), and the user navigates away.
+   */
+  abort() {
+    this.controller.abort();
+  }
+}

--- a/src/app/pagination/html-pages/index.ts
+++ b/src/app/pagination/html-pages/index.ts
@@ -1,0 +1,5 @@
+// Derived from @talers/html-pages v0.5.5 (https://www.npmjs.com/package/@talers/html-pages).
+export * from './HtmlPageSplitter';
+export * from './splitHtmlToPages';
+export * from './types';
+export * from './utilities';

--- a/src/app/pagination/html-pages/splitHtmlToPages.ts
+++ b/src/app/pagination/html-pages/splitHtmlToPages.ts
@@ -1,0 +1,245 @@
+// Derived from @talers/html-pages v0.5.5 (https://www.npmjs.com/package/@talers/html-pages).
+import type { HtmlPageSplitterOptions } from './types';
+import {
+  breakingSpaceCharacters,
+  getUnbreakableSlice,
+  isElement,
+  makeAllParentListElementsTransparent,
+  yieldToMainThread,
+} from './utilities';
+
+/**
+ * @param html - The HTML string to split.
+ * @param options.container - The container element to use for the split. It's basically one page that is filled until it's full, then it's added to the pages array.
+ * @param options.classes - The classes to add to the container element.
+ */
+export async function* splitHtmlToPages(
+  html: string,
+  options: HtmlPageSplitterOptions = {},
+  signal?: { aborted?: boolean },
+): AsyncGenerator<string> {
+  if (options.debug) {
+    console.log('splitHtmlToPages', options);
+  }
+  const maxNumberOfPages = options.maxNumberOfPages ?? Infinity;
+
+  const container = options.container ?? document.createElement('div');
+  container.classList.add(...(options.classes ?? []));
+
+  if (options.container) {
+    container.innerHTML = '';
+  } else {
+    container.style.visibility = 'hidden';
+    container.style.position = 'fixed';
+    container.style.pointerEvents = 'none';
+    document.body.appendChild(container);
+  }
+
+  // Convert the html string to a DOM element.
+  let root: HTMLElement;
+
+  if (options.debugSourceContainer) {
+    options.debugSourceContainer.innerHTML = html;
+    root = options.debugSourceContainer;
+  } else {
+    const parser = new DOMParser();
+    root = parser.parseFromString(html, 'text/html').body;
+  }
+
+  // the maximum height of the container is the maximum height of the page.
+  // when the container height is bigger than the page height, we add a new page.
+  const pageHeight = container.clientHeight;
+
+  if (options.debug) {
+    console.log('pageHeight', pageHeight);
+  }
+
+  if (!options.container) {
+    container.style.height = 'auto';
+    container.style.maxHeight = 'none';
+    container.style.minHeight = `${pageHeight}px`;
+  }
+
+  let pagesCount = 0;
+
+  let source: Node = root;
+  let target: Node = container;
+
+  const waitForDebuggingPurposes = (
+    ms = options.debugWaitingTime ?? 1_000,
+  ): Promise<void> | void => {
+    if (options.debug) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+  };
+
+  const toNextPage = async () => {
+    container.innerHTML = '';
+    container.innerHTML = '';
+    source = root;
+    target = container;
+    pagesCount += 1;
+    await yieldToMainThread();
+  };
+
+  nextPage: while (source.firstChild) {
+    if (signal?.aborted) {
+      if (options.debug) {
+        console.log('Aborting splitting operation.');
+      }
+      return;
+    }
+
+    while (source.firstChild) {
+      const sourceNode = source.firstChild;
+
+      target.appendChild(sourceNode);
+
+      if (container.clientHeight > pageHeight) {
+        // `sourceNode` must be split
+        // so, first we create an empty clone of it and:
+        // - insert the full node back in the source
+        // - append the empty clone to the target
+        const targetNode = sourceNode.cloneNode(false);
+        targetNode.textContent = '';
+        source.insertBefore(sourceNode, source.firstChild);
+        target.appendChild(targetNode);
+
+        await waitForDebuggingPurposes();
+
+        if (container.clientHeight > pageHeight) {
+          // we're still overflowing even when the node is empty!
+          // this means a clean split: no need to split any text
+          // we remove the empty node from the target and add a new page
+          target.removeChild(targetNode);
+
+          await waitForDebuggingPurposes();
+
+          makeAllParentListElementsTransparent(sourceNode);
+          yield container.innerHTML;
+          await toNextPage();
+
+          if (pagesCount >= maxNumberOfPages) {
+            break nextPage;
+          }
+          continue nextPage;
+        }
+
+        // `sourceNode` is the node where a split should happen
+        // if it's a text node, then we need to find at which position to split it
+        if (sourceNode.nodeType === Node.TEXT_NODE) {
+          const sourceText = sourceNode.textContent ?? '';
+
+          // test if we go over the page height with only the first character
+          targetNode.textContent = sourceText[0];
+          if (container.clientHeight > pageHeight) {
+            // if we do, then we add a new page now
+            target.removeChild(targetNode);
+
+            await waitForDebuggingPurposes();
+
+            makeAllParentListElementsTransparent(sourceNode);
+            yield container.innerHTML;
+            await toNextPage();
+            if (pagesCount >= maxNumberOfPages) {
+              break nextPage;
+            }
+            continue nextPage;
+          }
+
+          // TODO: handle non-breaking words longer than the line width
+          let offset = 0;
+          do {
+            const nextOffset = getUnbreakableSlice(sourceText, offset + 1);
+            targetNode.textContent = sourceText.slice(0, nextOffset);
+
+            await waitForDebuggingPurposes();
+
+            if (container.clientHeight > pageHeight) {
+              break;
+            }
+
+            offset = nextOffset;
+          } while (targetNode.textContent.length < sourceText.length);
+
+          // we use dichotomy to find the character to split the text node at
+          // let start = 0;
+          // let end = sourceText.length;
+
+          // while (start !== end) {
+          // 	const offset = Math.ceil((start + end) / 2);
+          // 	targetNode.textContent = sourceText.slice(0, offset);
+
+          // 	await sleep();
+
+          // 	if (container.clientHeight > pageHeight) {
+          // 		if (end === offset) {
+          // 			end = offset - 1;
+          // 			break;
+          // 		}
+          // 		end = offset;
+          // 	} else {
+          // 		start = offset;
+          // 	}
+          // }
+
+          // found the offset!
+          if (offset === -1 || offset === sourceText.length) {
+            targetNode.textContent = sourceText;
+            source.removeChild(sourceNode);
+          } else {
+            targetNode.textContent = sourceText.slice(0, offset);
+
+            const isBreakingSpace = breakingSpaceCharacters.includes(
+              sourceText[offset],
+            );
+            sourceNode.textContent =
+              offset === -1
+                ? sourceText
+                : sourceText.slice(isBreakingSpace ? offset + 1 : offset);
+          }
+
+          makeAllParentListElementsTransparent(sourceNode);
+          yield container.innerHTML;
+          await toNextPage();
+
+          if (pagesCount >= maxNumberOfPages) {
+            break nextPage;
+          }
+          continue nextPage;
+        }
+
+        // else, we continue until we find the deepest non-text node
+        source = sourceNode;
+        target = targetNode;
+      } else {
+        if (
+          isElement(sourceNode) &&
+          isElement(source) &&
+          source.tagName === 'OL'
+        ) {
+          const start = Number(source.getAttribute('start') ?? '1');
+          source.setAttribute('start', `${start + 1}`);
+        }
+      }
+    }
+
+    // we've reached the end of the HTML
+    if (source !== root) {
+      console.error(
+        'Should never happen: reached the end of the HTML but source is not root. This is most likely a bug.',
+        { html },
+      );
+    }
+
+    if (container.firstChild) {
+      yield container.innerHTML;
+    }
+
+    break;
+  }
+
+  if (!options.container) {
+    document.body.removeChild(container);
+  }
+}

--- a/src/app/pagination/html-pages/splitHtmlToPages.ts
+++ b/src/app/pagination/html-pages/splitHtmlToPages.ts
@@ -48,7 +48,8 @@ export async function* splitHtmlToPages(
 
   // the maximum height of the container is the maximum height of the page.
   // when the container height is bigger than the page height, we add a new page.
-  const pageHeight = container.clientHeight;
+  const rawPageHeight = options.pageHeight ?? container.clientHeight;
+  const pageHeight = rawPageHeight > 0 ? rawPageHeight : 1;
 
   if (options.debug) {
     console.log('pageHeight', pageHeight);

--- a/src/app/pagination/html-pages/types.ts
+++ b/src/app/pagination/html-pages/types.ts
@@ -1,0 +1,44 @@
+// Derived from @talers/html-pages v0.5.5 (https://www.npmjs.com/package/@talers/html-pages).
+/**
+ * Options for the `HtmlPageSplitter` class.
+ */
+export type HtmlPageSplitterOptions = {
+  /**
+   * The container element to use for the split. It's basically one page that is filled until it's full, then it's added to the pages array.
+   * By default, a new invisible `div` element is created.
+   * Use this parameter if you want to:
+   * - Visually see the pages being split.
+   * - Split the HTML into a custom container element (example: not a `div`).
+   */
+  container?: HTMLElement;
+
+  /**
+   * The classes to add to the container element.
+   * Use it to apply your page styles to the container element.
+   */
+  classes?: string[];
+
+  /**
+   * The maximum number of pages to split the HTML into.
+   * By default, there is no limit.
+   */
+  maxNumberOfPages?: number;
+
+  /**
+   * Whether to enable debugging mode.
+   * In debugging mode, you can wait between split operations to visualize the process.
+   */
+  debug?: boolean;
+
+  /**
+   * The container element to use for debugging purposes.
+   * Use it to see the HTML being split.
+   */
+  debugSourceContainer?: HTMLElement;
+
+  /**
+   * The time to wait between split operations.
+   * Use this parameter along other debugging parameters to visualize the split process.
+   */
+  debugWaitingTime?: number;
+};

--- a/src/app/pagination/html-pages/types.ts
+++ b/src/app/pagination/html-pages/types.ts
@@ -25,6 +25,13 @@ export type HtmlPageSplitterOptions = {
   maxNumberOfPages?: number;
 
   /**
+   * Optional explicit page height in pixels. When provided, the splitter will
+   * treat this as the maximum height before moving overflowing content to the
+   * next page instead of relying on the container's computed height.
+   */
+  pageHeight?: number;
+
+  /**
    * Whether to enable debugging mode.
    * In debugging mode, you can wait between split operations to visualize the process.
    */

--- a/src/app/pagination/html-pages/utilities.ts
+++ b/src/app/pagination/html-pages/utilities.ts
@@ -1,0 +1,65 @@
+// Derived from @talers/html-pages v0.5.5 (https://www.npmjs.com/package/@talers/html-pages).
+/**
+ * \u2002 - En space
+ * \u2003 - Em space
+ * \u2004 - Third space
+ * \u2005 - Quarter space
+ * \u2006 - Six per em space
+ * \u2007 - Figure space <-- This one is non-breaking
+ * \u2008 - Punctuation space.
+ * \u2009 - Thin space.
+ * \u200A - Hair space.
+ * \u200B - Zero-width space.
+ */
+export const breakingSpaceCharacters =
+  ' \u2002\u2003\u2004\u2005\u2006\u2008\u2009\u200A\u200B';
+
+/**
+ * \u00AD - Soft hyphen.
+ */
+export const breakingCharacters: string = `${breakingSpaceCharacters}\t\n\r-–—\u00AD`;
+
+/**
+ * Yields to the event loop, allowing pending tasks to execute
+ * before continuing. More reliable than setTimeout(0).
+ */
+export const yieldToMainThread = (): Promise<void> =>
+  new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => resolve(undefined);
+    channel.port2.postMessage(undefined);
+  });
+
+export function getUnbreakableSlice(text: string, start = 0): number {
+  let offset = start;
+
+  for (const character of text.slice(start)) {
+    if (breakingCharacters.includes(character)) {
+      return offset;
+    }
+    offset += 1;
+  }
+
+  return offset;
+}
+
+/**
+ * Check if a Node is an Element
+ */
+export const isElement = (node: Node): node is Element =>
+  node.nodeType === Node.ELEMENT_NODE;
+
+/**
+ * Add the class `___follow-up-marker` to all parent list elements to
+ * make them transparent.
+ */
+export function makeAllParentListElementsTransparent(node: Node | null): void {
+  let parent = node?.parentNode;
+
+  while (parent) {
+    if (isElement(parent) && parent.tagName === 'LI') {
+      parent.classList.add('html-pages__follow-up-list-item');
+    }
+    parent = parent.parentNode;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate the @talers/html-pages splitter so that documents without <wdoc-page> elements are automatically paginated in the viewer
- vendor the library's TypeScript sources (until upstream ships JS) and add a regression test that verifies unpaginated HTML is wrapped in wdoc-page nodes

## Testing
- `CI=1 npm test -- --watch=false`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c24656058832b8c64a18337a25c1e)