### PR TITLE
Add zoom controls with auto-fit behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/service-worker": "^20.3.13",
         "@talers/html-pages": "^0.5.5",
         "jszip": "^3.10.1",
-        "puppeteer": "^24.30.0",
+        "puppeteer": "^24.31.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.8.1",
         "zone.js": "~0.15.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/service-worker": "^20.3.13",
     "@talers/html-pages": "^0.5.5",
     "jszip": "^3.10.1",
-    "puppeteer": "^24.30.0",
+    "puppeteer": "^24.31.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.8.1",
     "zone.js": "~0.15.0"

--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -20,6 +20,7 @@
         [navOpen]="isNavOpen"
         [title]="documentTitle"
         [zoom]="zoom"
+        [hasDocument]="!!htmlContent"
         (toggleNav)="toggleNav()"
         (save)="onSaveForms()"
         (zoomChange)="onZoomChange($event)"

--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -19,10 +19,12 @@
         [showSave]="showSave"
         [navOpen]="isNavOpen"
         [title]="documentTitle"
+        [zoom]="zoom"
         (toggleNav)="toggleNav()"
         (save)="onSaveForms()"
+        (zoomChange)="onZoomChange($event)"
       ></app-topbar>
-      <app-viewer [htmlContent]="htmlContent"></app-viewer>
+      <app-viewer [htmlContent]="htmlContent" [zoom]="zoom"></app-viewer>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -38,7 +38,7 @@ export class AppComponent implements OnInit, OnDestroy {
   zoom = 100;
   private readonly defaultTitle = 'WDOC viewer';
   private readonly minZoom = 25;
-  private readonly maxZoom = 100;
+  private readonly maxZoom = 200;
   documentTitle = this.defaultTitle;
   private originalArrayBuffer: ArrayBuffer | null = null;
   private resizeListener?: () => void;
@@ -234,11 +234,11 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   private calculateFitZoom(): number | null {
-    if (!this.viewer || !this.viewer.nativeElement || !this.viewer.scrollElement) {
+    if (!this.viewer || !this.viewer.nativeElement) {
       return null;
     }
 
-    const containerWidth = this.viewer.scrollElement.clientWidth;
+    const containerWidth = this.viewer.nativeElement.clientWidth;
     if (!containerWidth) {
       return null;
     }
@@ -256,7 +256,7 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     const fitPercent = Math.floor(((containerWidth - 24) / baseWidth) * 100);
-    return this.clampZoom(fitPercent);
+    return fitPercent > 100 ? 100 : fitPercent;
   }
 
   private async fetchAndLoadWdoc(url: string): Promise<void> {
@@ -335,7 +335,11 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   async onSaveForms() {
-    if (!this.originalArrayBuffer || !this.viewer || !this.viewer.nativeElement) {
+    if (
+      !this.originalArrayBuffer ||
+      !this.viewer ||
+      !this.viewer.nativeElement
+    ) {
       return;
     }
     const newZip = await JSZip.loadAsync(this.originalArrayBuffer);

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -38,7 +38,7 @@ export class AppComponent implements OnInit, OnDestroy {
   zoom = 100;
   private readonly defaultTitle = 'WDOC viewer';
   private readonly minZoom = 25;
-  private readonly maxZoom = 400;
+  private readonly maxZoom = 100;
   documentTitle = this.defaultTitle;
   private originalArrayBuffer: ArrayBuffer | null = null;
   private resizeListener?: () => void;

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -35,7 +35,10 @@ export class AppComponent implements OnInit, OnDestroy {
   isNavOpen = false;
   sidenavMode: MatDrawerMode = 'over';
   showDropOverlay = false;
+  zoom = 100;
   private readonly defaultTitle = 'WDOC viewer';
+  private readonly minZoom = 25;
+  private readonly maxZoom = 400;
   documentTitle = this.defaultTitle;
   private originalArrayBuffer: ArrayBuffer | null = null;
   private resizeListener?: () => void;
@@ -63,7 +66,7 @@ export class AppComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     if (typeof window !== 'undefined') {
       this.applyResponsiveLayout(window.innerWidth);
-      this.resizeListener = () => this.applyResponsiveLayout(window.innerWidth);
+      this.resizeListener = () => this.onWindowResize(window.innerWidth);
       window.addEventListener('resize', this.resizeListener);
       this.beforePrintListener = () => {
         this.wasNavOpenBeforePrint = this.isNavOpen;
@@ -124,10 +127,12 @@ export class AppComponent implements OnInit, OnDestroy {
 
   toggleNav() {
     this.isNavOpen = !this.isNavOpen;
+    setTimeout(() => this.fitContentToViewport());
   }
 
   closeNav() {
     this.isNavOpen = false;
+    setTimeout(() => this.fitContentToViewport());
   }
 
   @HostListener('document:dragenter', ['$event'])
@@ -194,13 +199,64 @@ export class AppComponent implements OnInit, OnDestroy {
     return Array.from(types).includes('Files');
   }
 
+  private onWindowResize(width: number) {
+    this.applyResponsiveLayout(width);
+    this.fitContentToViewport();
+  }
+
   private applyResponsiveLayout(width: number) {
     const isDesktop = width >= 992;
     this.sidenavMode = isDesktop ? 'side' : 'over';
     if (isDesktop !== this.isDesktop) {
       this.isDesktop = isDesktop;
       this.isNavOpen = isDesktop;
+      setTimeout(() => this.fitContentToViewport());
     }
+  }
+
+  onZoomChange(zoom: number) {
+    this.zoom = this.clampZoom(zoom);
+  }
+
+  private clampZoom(value: number): number {
+    const bounded = Math.round(Number.isFinite(value) ? value : this.minZoom);
+    return Math.min(this.maxZoom, Math.max(this.minZoom, bounded));
+  }
+
+  private fitContentToViewport(force = false) {
+    const fitZoom = this.calculateFitZoom();
+    if (fitZoom === null) {
+      return;
+    }
+    if (force || this.zoom > fitZoom) {
+      this.zoom = fitZoom;
+    }
+  }
+
+  private calculateFitZoom(): number | null {
+    if (!this.viewer || !this.viewer.nativeElement || !this.viewer.scrollElement) {
+      return null;
+    }
+
+    const containerWidth = this.viewer.scrollElement.clientWidth;
+    if (!containerWidth) {
+      return null;
+    }
+
+    const pageElement = (this.viewer.nativeElement.querySelector('wdoc-page') ||
+      this.viewer.nativeElement.firstElementChild) as HTMLElement | null;
+
+    if (!pageElement) {
+      return null;
+    }
+
+    const baseWidth = pageElement.offsetWidth;
+    if (!baseWidth) {
+      return null;
+    }
+
+    const fitPercent = Math.floor(((containerWidth - 24) / baseWidth) * 100);
+    return this.clampZoom(fitPercent);
   }
 
   private async fetchAndLoadWdoc(url: string): Promise<void> {
@@ -250,7 +306,10 @@ export class AppComponent implements OnInit, OnDestroy {
       const processedHtml = await this.processHtml(zip, html);
       // Bypass Angular's security after processing the content
       this.htmlContent = this.sanitizer.bypassSecurityTrustHtml(processedHtml);
-      setTimeout(() => this.attachFormListeners());
+      setTimeout(() => {
+        this.attachFormListeners();
+        this.fitContentToViewport(true);
+      });
     } catch (error) {
       console.error('Error processing zip file:', error);
       alert('Error processing .wdoc file.');
@@ -262,6 +321,9 @@ export class AppComponent implements OnInit, OnDestroy {
       return;
     }
     const container = this.viewer.nativeElement;
+    if (!container) {
+      return;
+    }
     const controls = container.querySelectorAll('input, textarea, select');
     controls.forEach((el) => {
       el.addEventListener('input', () => (this.showSave = true));
@@ -270,7 +332,7 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   async onSaveForms() {
-    if (!this.originalArrayBuffer || !this.viewer) {
+    if (!this.originalArrayBuffer || !this.viewer || !this.viewer.nativeElement) {
       return;
     }
     const newZip = await JSZip.loadAsync(this.originalArrayBuffer);

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -306,6 +306,9 @@ export class AppComponent implements OnInit, OnDestroy {
       const processedHtml = await this.processHtml(zip, html);
       // Bypass Angular's security after processing the content
       this.htmlContent = this.sanitizer.bypassSecurityTrustHtml(processedHtml);
+      if (!this.isDesktop) {
+        this.isNavOpen = false;
+      }
       setTimeout(() => {
         this.attachFormListeners();
         this.fitContentToViewport(true);

--- a/src/app/topbar/topbar.component.css
+++ b/src/app/topbar/topbar.component.css
@@ -33,8 +33,62 @@
   font-size: 1.25rem;
 }
 
-.topbar-save {
+.topbar-actions {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.zoom-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 999px;
+  background: #f8f8f8;
+  padding: 0.25rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.zoom-button {
+  width: 36px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  font-size: 1.15rem;
+  font-weight: 700;
+  cursor: pointer;
+  border-radius: 999px;
+  transition: background 0.15s ease;
+}
+
+.zoom-button:hover,
+.zoom-button:focus-visible {
+  background: #eaeaea;
+  outline: none;
+}
+
+.zoom-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0 0.35rem;
+  border-left: 1px solid #e0e0e0;
+  border-right: 1px solid #e0e0e0;
+}
+
+.zoom-input input {
+  width: 56px;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: right;
+  outline: none;
+}
+
+.topbar-save {
   background-color: #4caf50;
   border: none;
   color: #fff;

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -12,36 +12,38 @@
   </button>
   <div class="topbar-title" [attr.title]="title">{{ title }}</div>
   <div class="topbar-actions">
-    <div class="zoom-controls" aria-label="Zoom controls">
-      <button
-        type="button"
-        class="zoom-button"
-        (click)="onZoomStep(-10)"
-        aria-label="Zoom out"
-      >
-        −
-      </button>
-      <label class="zoom-input" aria-label="Zoom percentage">
-        <input
-          type="text"
-          inputmode="numeric"
-          pattern="[0-9]*"
-          [value]="zoomValue"
-          (input)="onZoomInput($event)"
-          (blur)="onZoomCommit()"
-          (keydown.enter)="onZoomCommit()"
-        />
-        <span>%</span>
-      </label>
-      <button
-        type="button"
-        class="zoom-button"
-        (click)="onZoomStep(10)"
-        aria-label="Zoom in"
-      >
-        +
-      </button>
-    </div>
+    @if (hasDocument) {
+      <div class="zoom-controls" aria-label="Zoom controls">
+        <button
+          type="button"
+          class="zoom-button"
+          (click)="onZoomStep(-10)"
+          aria-label="Zoom out"
+        >
+          −
+        </button>
+        <label class="zoom-input" aria-label="Zoom percentage">
+          <input
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            [value]="zoomValue"
+            (input)="onZoomInput($event)"
+            (blur)="onZoomCommit()"
+            (keydown.enter)="onZoomCommit()"
+          />
+          <span>%</span>
+        </label>
+        <button
+          type="button"
+          class="zoom-button"
+          (click)="onZoomStep(10)"
+          aria-label="Zoom in"
+        >
+          +
+        </button>
+      </div>
+    }
     <button
       class="topbar-save"
       type="button"

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -11,12 +11,44 @@
     <span></span>
   </button>
   <div class="topbar-title" [attr.title]="title">{{ title }}</div>
-  <button
-    class="topbar-save"
-    type="button"
-    (click)="onSave()"
-    [hidden]="!showSave"
-  >
-    Save
-  </button>
+  <div class="topbar-actions">
+    <div class="zoom-controls" aria-label="Zoom controls">
+      <button
+        type="button"
+        class="zoom-button"
+        (click)="onZoomStep(-10)"
+        aria-label="Zoom out"
+      >
+        −
+      </button>
+      <label class="zoom-input" aria-label="Zoom percentage">
+        <input
+          type="text"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          [value]="zoomValue"
+          (input)="onZoomInput($event)"
+          (blur)="onZoomCommit()"
+          (keydown.enter)="onZoomCommit()"
+        />
+        <span>%</span>
+      </label>
+      <button
+        type="button"
+        class="zoom-button"
+        (click)="onZoomStep(10)"
+        aria-label="Zoom in"
+      >
+        +
+      </button>
+    </div>
+    <button
+      class="topbar-save"
+      type="button"
+      (click)="onSave()"
+      [hidden]="!showSave"
+    >
+      Save
+    </button>
+  </div>
 </header>

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -41,6 +41,7 @@ describe('TopbarComponent', () => {
   });
 
   it('emits zoomChange when zoom buttons are used', () => {
+    component.hasDocument = true;
     spyOn(component.zoomChange, 'emit');
     fixture.detectChanges();
     const buttons = fixture.nativeElement.querySelectorAll('.zoom-button');
@@ -49,6 +50,7 @@ describe('TopbarComponent', () => {
   });
 
   it('emits parsed zoom value from input on commit', () => {
+    component.hasDocument = true;
     spyOn(component.zoomChange, 'emit');
     fixture.detectChanges();
     const input: HTMLInputElement = fixture.nativeElement.querySelector(

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -39,4 +39,24 @@ describe('TopbarComponent', () => {
     );
     expect(el.textContent?.trim()).toBe('My Document');
   });
+
+  it('emits zoomChange when zoom buttons are used', () => {
+    spyOn(component.zoomChange, 'emit');
+    fixture.detectChanges();
+    const buttons = fixture.nativeElement.querySelectorAll('.zoom-button');
+    (buttons[0] as HTMLButtonElement).click();
+    expect(component.zoomChange.emit).toHaveBeenCalledWith(90);
+  });
+
+  it('emits parsed zoom value from input on commit', () => {
+    spyOn(component.zoomChange, 'emit');
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector(
+      '.zoom-input input'
+    );
+    input.value = '150';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new Event('blur'));
+    expect(component.zoomChange.emit).toHaveBeenCalledWith(150);
+  });
 });

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -8,12 +15,21 @@ import { CommonModule } from '@angular/common';
   templateUrl: './topbar.component.html',
   styleUrls: ['./topbar.component.css'],
 })
-export class TopbarComponent {
+export class TopbarComponent implements OnChanges {
   @Input() showSave = false;
   @Input() navOpen = false;
   @Input() title = 'WDOC viewer';
+  @Input() zoom = 100;
   @Output() toggleNav = new EventEmitter<void>();
   @Output() save = new EventEmitter<void>();
+  @Output() zoomChange = new EventEmitter<number>();
+  zoomValue = '100';
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['zoom']) {
+      this.zoomValue = `${this.zoom}`;
+    }
+  }
 
   onToggleNav() {
     this.toggleNav.emit();
@@ -21,5 +37,19 @@ export class TopbarComponent {
 
   onSave() {
     this.save.emit();
+  }
+
+  onZoomInput(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.zoomValue = value.replace(/\D+/g, '');
+  }
+
+  onZoomCommit() {
+    const parsed = parseInt(this.zoomValue, 10);
+    this.zoomChange.emit(Number.isFinite(parsed) ? parsed : this.zoom);
+  }
+
+  onZoomStep(delta: number) {
+    this.zoomChange.emit(this.zoom + delta);
   }
 }

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -20,6 +20,7 @@ export class TopbarComponent implements OnChanges {
   @Input() navOpen = false;
   @Input() title = 'WDOC viewer';
   @Input() zoom = 100;
+  @Input() hasDocument = false;
   @Output() toggleNav = new EventEmitter<void>();
   @Output() save = new EventEmitter<void>();
   @Output() zoomChange = new EventEmitter<number>();

--- a/src/app/viewer/viewer.component.css
+++ b/src/app/viewer/viewer.component.css
@@ -20,5 +20,6 @@
   .viewer-content,
   .viewer-content wdoc-page {
     transform: none !important;
+    zoom: 1 !important;
   }
 }

--- a/src/app/viewer/viewer.component.css
+++ b/src/app/viewer/viewer.component.css
@@ -1,25 +1,10 @@
-.viewer-scroll {
-  height: 100%;
-  overflow: auto;
-  display: flex;
-  justify-content: center;
-  padding: 1rem 0.5rem;
-}
-
-.viewer-content {
-  transform-origin: top center;
-  transition: transform 0.12s ease-in-out;
-}
-
-.viewer-content wdoc-page {
+wdoc-page {
   transform-origin: top center;
   transition: transform 0.12s ease-in-out;
 }
 
 @media print {
-  .viewer-content,
-  .viewer-content wdoc-page {
-    transform: none !important;
+  wdoc-page {
     zoom: 1 !important;
   }
 }

--- a/src/app/viewer/viewer.component.css
+++ b/src/app/viewer/viewer.component.css
@@ -1,1 +1,12 @@
-/* viewer specific styles can go here */
+.viewer-scroll {
+  height: 100%;
+  overflow: auto;
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0.5rem;
+}
+
+.viewer-content {
+  transform-origin: top center;
+  transition: transform 0.12s ease-in-out;
+}

--- a/src/app/viewer/viewer.component.css
+++ b/src/app/viewer/viewer.component.css
@@ -10,3 +10,15 @@
   transform-origin: top center;
   transition: transform 0.12s ease-in-out;
 }
+
+.viewer-content wdoc-page {
+  transform-origin: top center;
+  transition: transform 0.12s ease-in-out;
+}
+
+@media print {
+  .viewer-content,
+  .viewer-content wdoc-page {
+    transform: none !important;
+  }
+}

--- a/src/app/viewer/viewer.component.html
+++ b/src/app/viewer/viewer.component.html
@@ -1,7 +1,5 @@
 @if (htmlContent) {
-  <div class="viewer-scroll" #scrollContainer>
-    <div #contentContainer class="viewer-content">
-      <div [innerHTML]="htmlContent"></div>
-    </div>
-  </div>
+<div #contentContainer>
+  <div [innerHTML]="htmlContent"></div>
+</div>
 }

--- a/src/app/viewer/viewer.component.html
+++ b/src/app/viewer/viewer.component.html
@@ -1,5 +1,7 @@
 @if (htmlContent) {
-  <div #contentContainer>
-    <div [innerHTML]="htmlContent"></div>
+  <div class="viewer-scroll" #scrollContainer>
+    <div #contentContainer class="viewer-content">
+      <div [innerHTML]="htmlContent"></div>
+    </div>
   </div>
 }

--- a/src/app/viewer/viewer.component.spec.ts
+++ b/src/app/viewer/viewer.component.spec.ts
@@ -24,4 +24,15 @@ describe('ViewerComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('hello');
   });
+
+  it('applies zoom to the content container', async () => {
+    component.htmlContent = '<p>zoom</p>' as any;
+    component.zoom = 150;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const content = fixture.nativeElement.querySelector(
+      '.viewer-content'
+    ) as HTMLElement;
+    expect(content.style.transform).toContain('1.5');
+  });
 });

--- a/src/app/viewer/viewer.component.spec.ts
+++ b/src/app/viewer/viewer.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ViewerComponent } from './viewer.component';
 
 describe('ViewerComponent', () => {
   let fixture: ComponentFixture<ViewerComponent>;
   let component: ViewerComponent;
+  let sanitizer: DomSanitizer;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -12,6 +14,7 @@ describe('ViewerComponent', () => {
 
     fixture = TestBed.createComponent(ViewerComponent);
     component = fixture.componentInstance;
+    sanitizer = TestBed.inject(DomSanitizer);
   });
 
   it('should create', () => {
@@ -26,13 +29,14 @@ describe('ViewerComponent', () => {
   });
 
   it('applies zoom to the content container', async () => {
-    component.htmlContent = '<p>zoom</p>' as any;
+    const content: SafeHtml = sanitizer.bypassSecurityTrustHtml(
+      '<wdoc-container><wdoc-page>zoom</wdoc-page></wdoc-container>'
+    );
+    component.htmlContent = content;
     component.zoom = 150;
     fixture.detectChanges();
     await fixture.whenStable();
-    const content = fixture.nativeElement.querySelector(
-      '.viewer-content'
-    ) as HTMLElement;
-    expect(content.style.transform).toContain('1.5');
+    const page = fixture.nativeElement.querySelector('wdoc-page') as HTMLElement;
+    expect(page.style.transform).toContain('1.5');
   });
 });

--- a/src/app/viewer/viewer.component.spec.ts
+++ b/src/app/viewer/viewer.component.spec.ts
@@ -37,6 +37,6 @@ describe('ViewerComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     const page = fixture.nativeElement.querySelector('wdoc-page') as HTMLElement;
-    expect(page.style.transform).toContain('1.5');
+    expect(page.style.zoom).toBe('1.5');
   });
 });

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -59,15 +59,17 @@ export class ViewerComponent implements AfterViewInit, OnChanges {
     ) as HTMLElement[];
 
     if (pages.length === 0) {
-      container.style.transform = `scale(${scale})`;
-      container.style.transformOrigin = 'top center';
+      container.style.zoom = `${scale}`;
+      container.style.transform = '';
       return;
     }
 
+    container.style.zoom = '';
     container.style.transform = '';
     pages.forEach((page) => {
+      page.style.transform = '';
       page.style.transformOrigin = 'top center';
-      page.style.transform = `scale(${scale})`;
+      page.style.zoom = `${scale}`;
     });
   }
 }

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  Input,
+  AfterViewInit,
+  ElementRef,
+  ViewChild,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SafeHtml } from '@angular/platform-browser';
 
@@ -9,15 +17,41 @@ import { SafeHtml } from '@angular/platform-browser';
   templateUrl: './viewer.component.html',
   styleUrls: ['./viewer.component.css'],
 })
-export class ViewerComponent implements AfterViewInit {
+export class ViewerComponent implements AfterViewInit, OnChanges {
   @Input() htmlContent: SafeHtml | null = null;
-  @ViewChild('contentContainer') contentContainer!: ElementRef;
+  @Input() zoom = 100;
+  @ViewChild('contentContainer') contentContainer?: ElementRef;
+  @ViewChild('scrollContainer') scrollContainer?: ElementRef;
+  private viewInitialized = false;
 
   ngAfterViewInit() {
-    // scaling or other operations could go here
+    this.viewInitialized = true;
+    this.applyZoom();
   }
 
-  get nativeElement(): HTMLElement {
-    return this.contentContainer.nativeElement as HTMLElement;
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['zoom'] && this.viewInitialized) {
+      this.applyZoom();
+    }
+    if (changes['htmlContent'] && this.viewInitialized) {
+      setTimeout(() => this.applyZoom());
+    }
+  }
+
+  get nativeElement(): HTMLElement | undefined {
+    return this.contentContainer?.nativeElement as HTMLElement;
+  }
+
+  get scrollElement(): HTMLElement | undefined {
+    return this.scrollContainer?.nativeElement as HTMLElement;
+  }
+
+  private applyZoom() {
+    const container = this.contentContainer?.nativeElement as HTMLElement | null;
+    if (!container) {
+      return;
+    }
+    const scale = Math.max(10, this.zoom) / 100;
+    container.style.transform = `scale(${scale})`;
   }
 }

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -42,33 +42,19 @@ export class ViewerComponent implements AfterViewInit, OnChanges {
     return this.contentContainer?.nativeElement as HTMLElement;
   }
 
-  get scrollElement(): HTMLElement | undefined {
-    return this.scrollContainer?.nativeElement as HTMLElement;
-  }
-
   private applyZoom() {
-    const container = this.contentContainer?.nativeElement as HTMLElement | null;
+    const container = this.contentContainer
+      ?.nativeElement as HTMLElement | null;
     if (!container) {
       return;
     }
     const scale = Math.max(10, this.zoom) / 100;
-    container.style.setProperty('--viewer-scale', `${scale}`);
 
     const pages = Array.from(
       container.querySelectorAll('wdoc-page')
     ) as HTMLElement[];
 
-    if (pages.length === 0) {
-      container.style.zoom = `${scale}`;
-      container.style.transform = '';
-      return;
-    }
-
-    container.style.zoom = '';
-    container.style.transform = '';
     pages.forEach((page) => {
-      page.style.transform = '';
-      page.style.transformOrigin = 'top center';
       page.style.zoom = `${scale}`;
     });
   }

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -52,6 +52,22 @@ export class ViewerComponent implements AfterViewInit, OnChanges {
       return;
     }
     const scale = Math.max(10, this.zoom) / 100;
-    container.style.transform = `scale(${scale})`;
+    container.style.setProperty('--viewer-scale', `${scale}`);
+
+    const pages = Array.from(
+      container.querySelectorAll('wdoc-page')
+    ) as HTMLElement[];
+
+    if (pages.length === 0) {
+      container.style.transform = `scale(${scale})`;
+      container.style.transformOrigin = 'top center';
+      return;
+    }
+
+    container.style.transform = '';
+    pages.forEach((page) => {
+      page.style.transformOrigin = 'top center';
+      page.style.transform = `scale(${scale})`;
+    });
   }
 }

--- a/src/assets/wdoc-styles.css
+++ b/src/assets/wdoc-styles.css
@@ -58,6 +58,7 @@ wdoc-page {
     page-break-inside: avoid;
     break-after: page;
     break-inside: avoid;
+    zoom: 1 !important;
   }
 
   wdoc-page:last-child {


### PR DESCRIPTION
## Summary
- add zoom controls to the top bar with +/- buttons and a percent input
- apply zoom scaling inside the viewer and center the document content
- auto-fit the zoom level on load and resize so pages stay fully visible

## Testing
- ng test --watch=false --progress=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f7bf83200832b891b0be2df20b96e)