### PR TITLE
Enforce 80% coverage for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Run unit tests
         env:
           CI: true
-        run: npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false
+        run: npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false --code-coverage

--- a/angular.json
+++ b/angular.json
@@ -80,7 +80,7 @@
             "karmaConfig": "karma.conf.js",
             "watch": false,
             "browsers": "ChromeHeadlessNoSandbox",
-            "codeCoverage": false,
+            "codeCoverage": true,
             "assets": [
               {
                 "glob": "**/*",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,14 @@ module.exports = function (config) {
       dir: require("path").join(__dirname, "./coverage"),
       subdir: ".",
       reporters: [{ type: "html" }, { type: "text-summary" }],
+      check: {
+        global: {
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
+        },
+      },
     },
     reporters: ["progress", "kjhtml"],
     port: 9876,

--- a/src/app/pagination/html-pages/html-pages.spec.ts
+++ b/src/app/pagination/html-pages/html-pages.spec.ts
@@ -1,0 +1,116 @@
+import { HtmlPageSplitter } from './HtmlPageSplitter';
+import { splitHtmlToPages } from './splitHtmlToPages';
+import {
+  getUnbreakableSlice,
+  isElement,
+  makeAllParentListElementsTransparent,
+} from './utilities';
+
+describe('html-pages utilities', () => {
+  it('calculates the next breakable slice respecting breaking characters', () => {
+    expect(getUnbreakableSlice('hello world')).toBe(5);
+    expect(getUnbreakableSlice('non­breaking')).toBe(3);
+    expect(getUnbreakableSlice('already-breakable')).toBe(7);
+    expect(getUnbreakableSlice('nowrap')).toBe(6);
+  });
+
+  it('detects element nodes correctly', () => {
+    const element = document.createElement('div');
+    const textNode = document.createTextNode('text');
+
+    expect(isElement(element)).toBeTrue();
+    expect(isElement(textNode)).toBeFalse();
+  });
+
+  it('marks parent list elements as transparent follow ups', () => {
+    const list = document.createElement('ul');
+    const item = document.createElement('li');
+    const inner = document.createElement('span');
+
+    item.appendChild(inner);
+    list.appendChild(item);
+
+    makeAllParentListElementsTransparent(inner);
+
+    expect(item.classList.contains('html-pages__follow-up-list-item')).toBeTrue();
+    expect(list.classList.contains('html-pages__follow-up-list-item')).toBeFalse();
+  });
+});
+
+describe('splitHtmlToPages', () => {
+  const createCountingContainer = (): HTMLElement => {
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'clientHeight', {
+      get() {
+        return this.childNodes.length;
+      },
+    });
+    return container;
+  };
+
+  it('splits content into multiple pages based on page height', async () => {
+    const container = createCountingContainer();
+    const html = '<p>first</p><p>second</p>';
+    const pages: string[] = [];
+
+    for await (const page of splitHtmlToPages(html, {
+      container,
+      pageHeight: 1,
+    })) {
+      pages.push(page);
+    }
+
+    expect(pages.length).toBe(2);
+    expect(pages[0]).toContain('first');
+    expect(pages[1]).toContain('second');
+  });
+
+  it('respects the maximum number of pages option', async () => {
+    const container = createCountingContainer();
+    const html = '<div>one</div><div>two</div><div>three</div>';
+    const pages: string[] = [];
+
+    for await (const page of splitHtmlToPages(html, {
+      container,
+      pageHeight: 1,
+      maxNumberOfPages: 1,
+    })) {
+      pages.push(page);
+    }
+
+    expect(pages.length).toBe(1);
+    expect(pages[0]).toContain('one');
+    expect(pages[0]).not.toContain('two');
+  });
+});
+
+describe('HtmlPageSplitter', () => {
+  it('aborts ongoing splits when requested', async () => {
+    const splitter = new HtmlPageSplitter({
+      container: (() => {
+        const container = document.createElement('div');
+        Object.defineProperty(container, 'clientHeight', {
+          get() {
+            return this.childNodes.length;
+          },
+        });
+        return container;
+      })(),
+      pageHeight: 1,
+    });
+
+    const pages: string[] = [];
+    const iterator = splitter.split('<p>a</p><p>b</p>');
+
+    const first = await iterator.next();
+    pages.push(first.value as string);
+
+    splitter.abort();
+
+    const second = await iterator.next();
+
+    expect(second.done).toBeTrue();
+    expect(pages.length).toBe(1);
+    expect(pages[0]).toContain('a');
+  });
+});

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -61,4 +61,20 @@ describe('TopbarComponent', () => {
     input.dispatchEvent(new Event('blur'));
     expect(component.zoomChange.emit).toHaveBeenCalledWith(150);
   });
+
+  it('falls back to the current zoom when an invalid value is entered', () => {
+    component.hasDocument = true;
+    component.zoom = 85;
+    spyOn(component.zoomChange, 'emit');
+    fixture.detectChanges();
+
+    const input: HTMLInputElement = fixture.nativeElement.querySelector(
+      '.zoom-input input'
+    );
+    input.value = 'abc';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new Event('blur'));
+
+    expect(component.zoomChange.emit).toHaveBeenCalledWith(85);
+  });
 });

--- a/src/app/viewer/viewer.component.spec.ts
+++ b/src/app/viewer/viewer.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ViewerComponent } from './viewer.component';
 
@@ -39,4 +39,55 @@ describe('ViewerComponent', () => {
     const page = fixture.nativeElement.querySelector('wdoc-page') as HTMLElement;
     expect(page.style.zoom).toBe('1.5');
   });
+
+  it('skips zoom application before the view initializes', () => {
+    const applySpy = spyOn<any>(component as any, 'applyZoom');
+    component.ngOnChanges({ zoom: { currentValue: 120, previousValue: 100 } } as any);
+
+    expect(applySpy).not.toHaveBeenCalled();
+  });
+
+  it('applies zoom changes once initialized', fakeAsync(() => {
+    const content: SafeHtml = sanitizer.bypassSecurityTrustHtml(
+      '<wdoc-container><wdoc-page>zoom</wdoc-page></wdoc-container>'
+    );
+    component.htmlContent = content;
+    fixture.detectChanges();
+    tick();
+
+    component.zoom = 110;
+    const applySpy = spyOn<any>(component as any, 'applyZoom').and.callThrough();
+    component.ngOnChanges({ zoom: { currentValue: 110, previousValue: 100 } } as any);
+    tick();
+
+    expect(applySpy).toHaveBeenCalled();
+    const page = fixture.nativeElement.querySelector('wdoc-page') as HTMLElement;
+    expect(page.style.zoom).toBe('1.1');
+  }));
+
+  it('ignores applyZoom when the container is missing', () => {
+    const apply = (component as any).applyZoom.bind(component);
+    component.contentContainer = undefined as any;
+    expect(() => apply()).not.toThrow();
+  });
+
+  it('reapplies zoom when htmlContent changes after init', fakeAsync(() => {
+    const content: SafeHtml = sanitizer.bypassSecurityTrustHtml(
+      '<wdoc-container><wdoc-page>first</wdoc-page></wdoc-container>'
+    );
+    component.htmlContent = content;
+    fixture.detectChanges();
+    tick();
+
+    const applySpy = spyOn<any>(component as any, 'applyZoom').and.callThrough();
+    component.htmlContent = sanitizer.bypassSecurityTrustHtml(
+      '<wdoc-container><wdoc-page>second</wdoc-page></wdoc-container>'
+    );
+    component.ngOnChanges({
+      htmlContent: { currentValue: 'new', previousValue: 'old' },
+    } as any);
+    tick();
+
+    expect(applySpy).toHaveBeenCalled();
+  }));
 });


### PR DESCRIPTION
## Summary
- enable Angular test runs to collect coverage by default
- enforce a global 80% coverage threshold through Karma configuration
- run CI unit tests with coverage enabled so GitHub Actions fails below the threshold

## Testing
- npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false --code-coverage *(fails due to current coverage below 80% threshold)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69203a94d6e8832b96bb6576298884be)