### PR TITLE
Allow ZIP files for document loading

### DIFF
--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -32,6 +32,6 @@
 
 @if (showDropOverlay) {
   <div class="drop-overlay" aria-live="assertive">
-    <div class="drop-message">drop your wdoc file here</div>
+    <div class="drop-message">drop your wdoc or zip file here</div>
   </div>
 }

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -264,12 +264,12 @@ describe('AppComponent', () => {
     expect(app.showSave).toBeTrue();
   });
 
-  it('loads a .wdoc from the url query parameter', async () => {
+  it('loads an archive from the url query parameter', async () => {
     const originalUrl = window.location.href;
     window.history.pushState(
       {},
       '',
-      '/?url=https%3A%2F%2Fexample.com%2Fsample.wdoc'
+      '/?url=https%3A%2F%2Fexample.com%2Fsample.zip'
     );
 
     const fixture = TestBed.createComponent(AppComponent);
@@ -282,7 +282,7 @@ describe('AppComponent', () => {
 
     app.ngOnInit();
 
-    const req = httpMock.expectOne('https://example.com/sample.wdoc');
+    const req = httpMock.expectOne('https://example.com/sample.zip');
     const buffer = new ArrayBuffer(1);
     req.flush(buffer);
 
@@ -381,11 +381,11 @@ describe('AppComponent', () => {
     expect(attachmentEntry.mime).toBe('text/plain');
   });
 
-  it('shows the drop overlay for dragged files and loads .wdoc files on drop', () => {
+  it('shows the drop overlay for dragged files and loads supported files on drop', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
 
-    const wdocFile = new File(['demo'], 'sample.wdoc');
+    const wdocFile = new File(['demo'], 'sample.zip');
     const fileList = createFileList([wdocFile]);
     const dataTransfer = {
       types: ['Files'],
@@ -824,27 +824,25 @@ describe('AppComponent', () => {
 
     await app['loadWdocFromArrayBuffer'](buffer);
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      'index.html not found in the .wdoc file.'
-    );
+    expect(alertSpy).toHaveBeenCalledWith('index.html not found in the archive.');
     expect(app.processHtml).not.toHaveBeenCalled();
   });
 
-  it('handles download errors while fetching remote .wdoc files', async () => {
+  it('handles download errors while fetching remote archives', async () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;
     const http = TestBed.inject(HttpClient);
     spyOn(http, 'get').and.returnValue(throwError(() => new Error('404')));
     const alertSpy = spyOn(window, 'alert');
 
-    await app['fetchAndLoadWdoc']('https://example.com/fail.wdoc');
+    await app['fetchAndLoadWdoc']('https://example.com/fail.zip');
 
     expect(alertSpy).toHaveBeenCalledWith(
-      'Error downloading .wdoc file from URL.'
+      'Error downloading .wdoc/.zip file from URL.'
     );
   });
 
-  it('ignores drop events without .wdoc files', () => {
+  it('ignores drop events without supported files', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;
     app.dragDepth = 2;
@@ -860,7 +858,7 @@ describe('AppComponent', () => {
 
     expect(app.dragDepth).toBe(0);
     expect(app.showDropOverlay).toBeFalse();
-    expect(alertSpy).toHaveBeenCalledWith('Please drop a .wdoc file.');
+    expect(alertSpy).toHaveBeenCalledWith('Please drop a .wdoc or .zip file.');
   });
 
   it('does not adjust zoom when fit calculation is unavailable', () => {

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -90,7 +90,7 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     const trimmedUrl = rawUrl.trim();
-    if (!trimmedUrl.toLowerCase().endsWith('.wdoc')) {
+    if (!this.isSupportedArchive(trimmedUrl)) {
       return;
     }
 
@@ -185,14 +185,14 @@ export class AppComponent implements OnInit, OnDestroy {
     if (!files?.length) {
       return;
     }
-    const wdocFile = Array.from(files).find((file) =>
-      file.name.toLowerCase().endsWith('.wdoc')
+    const archiveFile = Array.from(files).find((file) =>
+      this.isSupportedArchive(file.name)
     );
-    if (!wdocFile) {
-      alert('Please drop a .wdoc file.');
+    if (!archiveFile) {
+      alert('Please drop a .wdoc or .zip file.');
       return;
     }
-    this.onFileSelected(wdocFile);
+    this.onFileSelected(archiveFile);
   }
 
   private containsFiles(event: DragEvent): boolean {
@@ -270,8 +270,8 @@ export class AppComponent implements OnInit, OnDestroy {
       );
       await this.loadWdocFromArrayBuffer(arrayBuffer);
     } catch (error) {
-      console.error(`Error downloading .wdoc file from ${url}:`, error);
-      alert('Error downloading .wdoc file from URL.');
+      console.error(`Error downloading .wdoc/.zip file from ${url}:`, error);
+      alert('Error downloading .wdoc/.zip file from URL.');
     }
   }
 
@@ -303,7 +303,7 @@ export class AppComponent implements OnInit, OnDestroy {
         }
       }
       if (!indexFile) {
-        alert('index.html not found in the .wdoc file.');
+        alert('index.html not found in the archive.');
         return;
       }
       const html = await indexFile.async('text');
@@ -321,6 +321,11 @@ export class AppComponent implements OnInit, OnDestroy {
       console.error('Error processing zip file:', error);
       alert('Error processing .wdoc file.');
     }
+  }
+
+  private isSupportedArchive(name: string): boolean {
+    const lower = name.toLowerCase();
+    return lower.endsWith('.wdoc') || lower.endsWith('.zip');
   }
 
   private attachFormListeners() {

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -14,14 +14,14 @@
   </header>
   <div class="nav-content">
     <button type="button" class="nav-btn" (click)="triggerFileDialog()">
-      Open .wdoc file
+      Open .wdoc or .zip file
     </button>
     <input
       #fileInput
       type="file"
       class="sr-only"
       (change)="onFileChange($event)"
-      accept=".wdoc"
+      accept=".wdoc,.zip"
       aria-hidden="true"
       tabindex="-1"
     />

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -19,7 +19,7 @@ describe('NavbarComponent', () => {
   });
 
   it('should emit selected file', () => {
-    const file = new File(['dummy'], 'test.wdoc');
+    const file = new File(['dummy'], 'test.zip');
     let emitted: File | null = null;
     component.fileSelected.subscribe((f) => (emitted = f));
 
@@ -27,6 +27,6 @@ describe('NavbarComponent', () => {
     component.onFileChange(mockEvent);
 
     expect(emitted).toBeTruthy();
-    expect(emitted!.name).toBe('test.wdoc');
+    expect(emitted!.name).toBe('test.zip');
   });
 });


### PR DESCRIPTION
## Summary
- allow uploads, drops, and URL parameters to accept .zip archives alongside .wdoc files
- update UI text to reflect support for both formats and refine missing index alert
- adjust unit tests to cover .zip handling

## Testing
- CI=true npm test -- --watch=false --progress=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920967ad78c832b8c10d3f38dbd9c7c)