### PR TITLE
Add wdoc-content layout handling

### DIFF
--- a/src/assets/wdoc-styles.css
+++ b/src/assets/wdoc-styles.css
@@ -24,9 +24,16 @@ wdoc-page {
   margin-bottom: 20px;
 }
 
-wdoc-page > wdoc-footer,
-wdoc-page > doc-footer {
-  margin-top: auto;
+wdoc-header,
+wdoc-footer,
+doc-footer {
+  flex: 0 0 auto;
+  display: block;
+  width: 100%;
+}
+
+wdoc-content {
+  flex: 1 1 auto;
   display: block;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- add a dedicated <wdoc-content> flex container so page content fills space between headers and footers
- adjust pagination logic to wrap existing content in <wdoc-content> for both paginated and pre-paginated documents
- update styles and tests to reflect the new header/content/footer layout

## Testing
- CI=true npm test -- --watch=false --progress=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69209752fef8832b8bb4cf94250642ef)