### PR TITLE
Handle wdoc metadata placeholders

### DIFF
--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -720,7 +720,7 @@ describe('AppComponent', () => {
     try {
       const html =
         '<html><head></head><body>' +
-        '<wdoc-header>Page <wdoc-page></wdoc-page> / <wdoc-nbpages></wdoc-nbpages> - <wdoc-date format="Y"></wdoc-date></wdoc-header>' +
+        '<wdoc-header>Page <wdoc-pagenum></wdoc-pagenum> / <wdoc-nbpages></wdoc-nbpages> - <wdoc-date format="Y"></wdoc-date></wdoc-header>' +
         '<wdoc-footer>Date <wdoc-date></wdoc-date></wdoc-footer>' +
         '<wdoc-page><div>first</div></wdoc-page>' +
         '<wdoc-page><div>second - total <wdoc-nbpages></wdoc-nbpages></div></wdoc-page>' +
@@ -740,7 +740,7 @@ describe('AppComponent', () => {
         'Page 1 / 2 - 2024',
       );
       expect(
-        pages[0].querySelector('wdoc-header wdoc-page')?.textContent,
+        pages[0].querySelector('wdoc-header wdoc-pagenum')?.textContent,
       ).toBe('1');
       expect(
         pages[0].querySelector('wdoc-header wdoc-nbpages')?.textContent,

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -730,21 +730,39 @@ describe('AppComponent', () => {
       const processed = await app.processHtml(zip, html);
 
       const doc = new DOMParser().parseFromString(processed, 'text/html');
-      const pages = Array.from(doc.querySelectorAll('wdoc-page'));
+      const container = doc.querySelector('wdoc-container');
+      const pages = Array.from(
+        (container ?? doc.body).querySelectorAll('wdoc-page'),
+      ).filter((page) => page.parentElement === (container ?? doc.body));
 
       expect(pages.length).toBe(2);
       expect(pages[0].querySelector('wdoc-header')?.textContent).toBe(
         'Page 1 / 2 - 2024',
       );
+      expect(
+        pages[0].querySelector('wdoc-header wdoc-page')?.textContent,
+      ).toBe('1');
+      expect(
+        pages[0].querySelector('wdoc-header wdoc-nbpages')?.textContent,
+      ).toBe('2');
+      expect(
+        pages[0].querySelector('wdoc-header wdoc-date')?.textContent,
+      ).toBe('2024');
       expect(pages[1].querySelector('wdoc-header')?.textContent).toBe(
         'Page 2 / 2 - 2024',
       );
       expect(pages[0].querySelector('wdoc-footer')?.textContent).toBe(
         'Date 06/05/2024',
       );
+      expect(
+        pages[0].querySelector('wdoc-footer wdoc-date')?.textContent,
+      ).toBe('06/05/2024');
       expect(pages[1].querySelector('wdoc-content')?.textContent).toContain(
         'total 2',
       );
+      expect(
+        pages[1].querySelector('wdoc-content wdoc-nbpages')?.textContent,
+      ).toBe('2');
     } finally {
       jasmine.clock().uninstall();
     }

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -707,6 +707,49 @@ describe('AppComponent', () => {
     expect(container?.querySelectorAll(':scope > wdoc-footer').length).toBe(0);
   });
 
+  it('replaces page metadata placeholders after templates are applied', async () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    const http = TestBed.inject(HttpClient);
+
+    spyOn(http, 'get').and.returnValue(of(''));
+
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date('2024-05-06T12:00:00Z'));
+
+    try {
+      const html =
+        '<html><head></head><body>' +
+        '<wdoc-header>Page <wdoc-page></wdoc-page> / <wdoc-nbpages></wdoc-nbpages> - <wdoc-date format="Y"></wdoc-date></wdoc-header>' +
+        '<wdoc-footer>Date <wdoc-date></wdoc-date></wdoc-footer>' +
+        '<wdoc-page><div>first</div></wdoc-page>' +
+        '<wdoc-page><div>second - total <wdoc-nbpages></wdoc-nbpages></div></wdoc-page>' +
+        '</body></html>';
+
+      const zip = new JSZip();
+      const processed = await app.processHtml(zip, html);
+
+      const doc = new DOMParser().parseFromString(processed, 'text/html');
+      const pages = Array.from(doc.querySelectorAll('wdoc-page'));
+
+      expect(pages.length).toBe(2);
+      expect(pages[0].querySelector('wdoc-header')?.textContent).toBe(
+        'Page 1 / 2 - 2024',
+      );
+      expect(pages[1].querySelector('wdoc-header')?.textContent).toBe(
+        'Page 2 / 2 - 2024',
+      );
+      expect(pages[0].querySelector('wdoc-footer')?.textContent).toBe(
+        'Date 06/05/2024',
+      );
+      expect(pages[1].querySelector('wdoc-content')?.textContent).toContain(
+        'total 2',
+      );
+    } finally {
+      jasmine.clock().uninstall();
+    }
+  });
+
   it('normalizes fit zoom to 100% when content already fits', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -673,9 +673,12 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private applyPageMetadata(doc: Document): void {
     const container = doc.querySelector('wdoc-container');
-    const pages = container
-      ? Array.from(container.querySelectorAll(':scope > wdoc-page'))
-      : Array.from(doc.querySelectorAll('wdoc-page'));
+    const targetRoots = container ? [container] : [doc.body];
+    const pages = targetRoots.flatMap((root) =>
+      Array.from(root.querySelectorAll('wdoc-page')).filter(
+        (page) => page.parentElement === root,
+      ),
+    );
     const totalPages = pages.length;
     const now = new Date();
 
@@ -705,7 +708,7 @@ export class AppComponent implements OnInit, OnDestroy {
   ): void {
     const placeholders = Array.from(container.querySelectorAll(selector));
     placeholders.forEach((el) => {
-      el.replaceWith(doc.createTextNode(text));
+      el.textContent = text;
     });
   }
 
@@ -714,7 +717,7 @@ export class AppComponent implements OnInit, OnDestroy {
     placeholders.forEach((el) => {
       const format = el.getAttribute('format') || undefined;
       const formatted = this.formatDate(date, format);
-      el.replaceWith(doc.createTextNode(formatted));
+      el.textContent = formatted;
     });
   }
 

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -686,7 +686,7 @@ export class AppComponent implements OnInit, OnDestroy {
       const pageNumber = (index + 1).toString();
       this.replacePlaceholders(
         page,
-        'wdoc-page',
+        'wdoc-pagenum',
         pageNumber,
         page.ownerDocument || doc,
       );

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -553,6 +553,8 @@ export class AppComponent implements OnInit, OnDestroy {
       this.applyTemplatesToPages(doc, templateMeasurements);
     }
 
+    this.applyPageMetadata(doc);
+
     await this.populateFormsFromZip(zip, doc);
     return doc.documentElement.outerHTML;
   }
@@ -667,6 +669,72 @@ export class AppComponent implements OnInit, OnDestroy {
     page.appendChild(fragment);
 
     return content;
+  }
+
+  private applyPageMetadata(doc: Document): void {
+    const container = doc.querySelector('wdoc-container');
+    const pages = container
+      ? Array.from(container.querySelectorAll(':scope > wdoc-page'))
+      : Array.from(doc.querySelectorAll('wdoc-page'));
+    const totalPages = pages.length;
+    const now = new Date();
+
+    pages.forEach((page, index) => {
+      const pageNumber = (index + 1).toString();
+      this.replacePlaceholders(
+        page,
+        'wdoc-page',
+        pageNumber,
+        page.ownerDocument || doc,
+      );
+      this.replacePlaceholders(
+        page,
+        'wdoc-nbpages',
+        totalPages.toString(),
+        page.ownerDocument || doc,
+      );
+      this.replaceDatePlaceholders(page, now, page.ownerDocument || doc);
+    });
+  }
+
+  private replacePlaceholders(
+    container: Element,
+    selector: string,
+    text: string,
+    doc: Document,
+  ): void {
+    const placeholders = Array.from(container.querySelectorAll(selector));
+    placeholders.forEach((el) => {
+      el.replaceWith(doc.createTextNode(text));
+    });
+  }
+
+  private replaceDatePlaceholders(page: Element, date: Date, doc: Document): void {
+    const placeholders = Array.from(page.querySelectorAll('wdoc-date'));
+    placeholders.forEach((el) => {
+      const format = el.getAttribute('format') || undefined;
+      const formatted = this.formatDate(date, format);
+      el.replaceWith(doc.createTextNode(formatted));
+    });
+  }
+
+  private formatDate(date: Date, format = 'dd/mm/YYYY'): string {
+    const year = date.getFullYear().toString();
+    const month = this.padWithZero(date.getMonth() + 1);
+    const day = this.padWithZero(date.getDate());
+
+    let result = format;
+    result = result.replace(/YYYY/g, year);
+    result = result.replace(/Y/g, year);
+    result = result.replace(/MM/g, month);
+    result = result.replace(/mm/g, month);
+    result = result.replace(/DD/g, day);
+    result = result.replace(/dd/g, day);
+    return result;
+  }
+
+  private padWithZero(value: number): string {
+    return value.toString().padStart(2, '0');
   }
 
   private measureTemplateHeight(template: Element): number {


### PR DESCRIPTION
## Summary
- replace metadata placeholders (<wdoc-page>, <wdoc-nbpages>, <wdoc-date>) after applying headers and footers
- add formatting helper for date placeholders with support for custom formats
- cover page metadata replacement with a new unit test

## Testing
- npm test -- --watch=false --progress=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920b3efe0b0832b925cf6b9456d32e8)