### PR TITLE
Add barcode rendering support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@angular/compiler-cli": "^20.3.13",
         "@playwright/test": "^1.43.1",
         "@types/jasmine": "^5.1.13",
+        "@types/qrcode": "^1.5.6",
         "jasmine-core": "~5.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -5648,6 +5649,16 @@
       "version": "1.3.14",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
       "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@angular/compiler-cli": "^20.3.13",
     "@playwright/test": "^1.43.1",
     "@types/jasmine": "^5.1.13",
+    "@types/qrcode": "^1.5.6",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -108,7 +108,9 @@ describe('AppComponent', () => {
     );
 
     const doc = new DOMParser().parseFromString(result, 'text/html');
-    const img = doc.querySelector('img');
+    const barcodeEl = doc.querySelector('wdoc-barcode');
+    const img = barcodeEl?.querySelector('img');
+    expect(barcodeEl?.getAttribute('text')).toBe('hello');
     expect(img?.getAttribute('src')).toBe('data:H');
   });
 
@@ -141,7 +143,9 @@ describe('AppComponent', () => {
     );
 
     const doc = new DOMParser().parseFromString(result, 'text/html');
-    const svg = doc.querySelector('svg');
+    const barcodeEl = doc.querySelector('wdoc-barcode');
+    const svg = barcodeEl?.querySelector('svg');
+    expect(barcodeEl?.getAttribute('text')).toBe('ABC123');
     expect(svg?.getAttribute('data-format')).toBe('CODE128');
     expect(svg?.getAttribute('data-value')).toBe('ABC123');
   });
@@ -171,7 +175,9 @@ describe('AppComponent', () => {
     );
 
     const doc = new DOMParser().parseFromString(result, 'text/html');
-    const img = doc.querySelector('img');
+    const barcodeEl = doc.querySelector('wdoc-barcode');
+    const img = barcodeEl?.querySelector('img');
+    expect(barcodeEl?.getAttribute('text')).toBe('abc');
     expect(img?.getAttribute('src')).toBe('data:default');
   });
 
@@ -194,7 +200,9 @@ describe('AppComponent', () => {
 
     expect(linearSpy).not.toHaveBeenCalled();
     const doc = new DOMParser().parseFromString(result, 'text/html');
-    expect(doc.querySelector('wdoc-barcode')?.textContent).toBe('123');
+    const barcodeEl = doc.querySelector('wdoc-barcode');
+    expect(barcodeEl?.getAttribute('text')).toBe('123');
+    expect(barcodeEl?.textContent).toBe('123');
   });
 
   it('removes empty barcode placeholders', async () => {
@@ -245,7 +253,10 @@ describe('AppComponent', () => {
     );
 
     const doc = new DOMParser().parseFromString(result, 'text/html');
-    const svg = doc.querySelector('svg');
+    const barcodeEl = doc.querySelector('wdoc-barcode');
+    const svg = barcodeEl?.querySelector('svg');
+    expect(barcodeEl?.getAttribute('class')).toBe('barcode');
+    expect(barcodeEl?.getAttribute('style')).toContain('width:100px');
     expect(svg?.getAttribute('data-format')).toBe('codabar');
     expect(svg?.getAttribute('class')).toBe('barcode');
     expect(svg?.getAttribute('style')).toContain('width:100px');
@@ -276,7 +287,11 @@ describe('AppComponent', () => {
     );
 
     const doc = new DOMParser().parseFromString(result, 'text/html');
-    expect(doc.querySelector('img')?.getAttribute('src')).toBe('data:qr');
+    const barcodeEl = doc.querySelector('wdoc-barcode');
+    expect(barcodeEl?.getAttribute('text')).toBe('value');
+    expect(barcodeEl?.querySelector('img')?.getAttribute('src')).toBe(
+      'data:qr',
+    );
   });
 
   it('maps supported linear barcode types to JsBarcode formats', () => {

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -735,6 +735,7 @@ export class AppComponent implements OnInit, OnDestroy {
         continue;
       }
 
+      barcode.setAttribute('text', value);
       const type = (barcode.getAttribute('type') || 'qrcode').toLowerCase();
       if (type === 'qrcode') {
         await this.renderQrCode(barcode, value, doc);
@@ -760,7 +761,7 @@ export class AppComponent implements OnInit, OnDestroy {
       const img = doc.createElement('img');
       img.setAttribute('src', dataUrl);
       this.copyBarcodeAttributes(barcode, img);
-      barcode.replaceWith(img);
+      barcode.replaceChildren(img);
     } catch (error) {
       console.error('Failed to render QR code', error);
     }
@@ -782,7 +783,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.copyBarcodeAttributes(barcode, svg);
     try {
       this.generateLinearBarcode(svg, value, format);
-      barcode.replaceWith(svg);
+      barcode.replaceChildren(svg);
     } catch (error) {
       console.error(`Failed to render barcode of type ${format}`, error);
     }

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -15,6 +15,9 @@ import { NavbarComponent } from '../navbar/navbar.component';
 import { ViewerComponent } from '../viewer/viewer.component';
 import { TopbarComponent } from '../topbar/topbar.component';
 import { MatDrawerMode, MatSidenavModule } from '@angular/material/sidenav';
+import { QRCodeToDataURLOptions } from 'qrcode';
+import QRCode from 'qrcode';
+import JsBarcode from 'jsbarcode';
 
 @Component({
   selector: 'app-root',
@@ -528,6 +531,8 @@ export class AppComponent implements OnInit, OnDestroy {
     newStyleEl.textContent = combinedCSS;
     doc.body.insertBefore(newStyleEl, doc.body.firstChild);
 
+    await this.renderBarcodes(doc);
+
     // 7. If the document does not contain any <wdoc-page> elements, paginate it.
     if (!doc.querySelector('wdoc-page')) {
       const templateMeasurements = this.prepareTemplates(doc);
@@ -719,6 +724,141 @@ export class AppComponent implements OnInit, OnDestroy {
       const formatted = this.formatDate(date, format);
       el.textContent = formatted;
     });
+  }
+
+  private async renderBarcodes(doc: Document): Promise<void> {
+    const barcodes = Array.from(doc.querySelectorAll('wdoc-barcode'));
+    for (const barcode of barcodes) {
+      const value = barcode.textContent?.trim();
+      if (!value) {
+        barcode.replaceWith(doc.createTextNode(''));
+        continue;
+      }
+
+      const type = (barcode.getAttribute('type') || 'qrcode').toLowerCase();
+      if (type === 'qrcode') {
+        await this.renderQrCode(barcode, value, doc);
+        continue;
+      }
+
+      await this.renderLinearBarcode(barcode, value, type, doc);
+    }
+  }
+
+  private async renderQrCode(
+    barcode: Element,
+    value: string,
+    doc: Document,
+  ): Promise<void> {
+    const errorCorrection = this.normalizeErrorCorrectionLevel(
+      barcode.getAttribute('errorcorrection'),
+    );
+    try {
+      const dataUrl = await this.generateQrCodeDataUrl(value, {
+        errorCorrectionLevel: errorCorrection,
+      });
+      const img = doc.createElement('img');
+      img.setAttribute('src', dataUrl);
+      this.copyBarcodeAttributes(barcode, img);
+      barcode.replaceWith(img);
+    } catch (error) {
+      console.error('Failed to render QR code', error);
+    }
+  }
+
+  private async renderLinearBarcode(
+    barcode: Element,
+    value: string,
+    type: string,
+    doc: Document,
+  ): Promise<void> {
+    const format = this.normalizeLinearBarcodeType(type);
+    if (!format) {
+      console.warn(`Unsupported barcode type: ${type}`);
+      return;
+    }
+
+    const svg = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    this.copyBarcodeAttributes(barcode, svg);
+    try {
+      this.generateLinearBarcode(svg, value, format);
+      barcode.replaceWith(svg);
+    } catch (error) {
+      console.error(`Failed to render barcode of type ${format}`, error);
+    }
+  }
+
+  private normalizeErrorCorrectionLevel(
+    level: string | null,
+  ): QRCodeToDataURLOptions['errorCorrectionLevel'] {
+    const upper = level?.toUpperCase();
+    switch (upper) {
+      case 'L':
+      case 'M':
+      case 'Q':
+      case 'H':
+        return upper;
+      default:
+        return 'M';
+    }
+  }
+
+  private normalizeLinearBarcodeType(type: string): string | null {
+    switch (type.toLowerCase()) {
+      case 'code128':
+        return 'CODE128';
+      case 'ean':
+        return 'EAN';
+      case 'upc':
+        return 'UPC';
+      case 'code39':
+        return 'CODE39';
+      case 'itf14':
+        return 'ITF14';
+      case 'msi':
+        return 'MSI';
+      case 'pharmacode':
+        return 'pharmacode';
+      case 'codabar':
+        return 'codabar';
+      default:
+        return null;
+    }
+  }
+
+  private copyBarcodeAttributes(source: Element, target: Element): void {
+    const attributesToCopy = [
+      'class',
+      'style',
+      'width',
+      'height',
+      'id',
+      'title',
+      'aria-label',
+      'aria-describedby',
+    ];
+
+    attributesToCopy.forEach((attr) => {
+      const value = source.getAttribute(attr);
+      if (value !== null) {
+        target.setAttribute(attr, value);
+      }
+    });
+  }
+
+  private generateLinearBarcode(
+    target: SVGElement,
+    value: string,
+    format: string,
+  ): void {
+    JsBarcode(target, value, { format });
+  }
+
+  private generateQrCodeDataUrl(
+    value: string,
+    options: QRCodeToDataURLOptions,
+  ): Promise<string> {
+    return QRCode.toDataURL(value, options);
   }
 
   private formatDate(date: Date, format = 'dd/mm/YYYY'): string {


### PR DESCRIPTION
## Summary
- add support for rendering `<wdoc-barcode>` elements as QR codes or linear barcodes using the bundled libraries
- handle default QR options, unsupported or empty barcode values, and preserve styling when converting to generated images/SVG
- expand unit coverage around barcode rendering and normalization helpers

## Testing
- npm test -- --watch=false --progress=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920c5a66714832bb326ce539d9c58c3)