### PR TITLE
Improve change detection and form handling

### DIFF
--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -25,7 +25,11 @@
         (save)="onSaveForms()"
         (zoomChange)="onZoomChange($event)"
       ></app-topbar>
-      <app-viewer [htmlContent]="htmlContent" [zoom]="zoom"></app-viewer>
+      <app-viewer
+        [htmlContent]="htmlContent"
+        [zoom]="zoom"
+        (formInteraction)="onFormInteraction()"
+      ></app-viewer>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -41,12 +41,7 @@ describe('AppComponent', () => {
   it('should mark showSave when form input changes', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;
-    const input = document.createElement('input');
-    const container = document.createElement('div');
-    container.appendChild(input);
-    app.viewer = { nativeElement: container } as any;
-    (app as any).attachFormListeners();
-    input.dispatchEvent(new Event('input'));
+    app.onFormInteraction();
     expect(app.showSave).toBeTrue();
   });
 
@@ -109,13 +104,11 @@ describe('AppComponent', () => {
 
     app.isNavOpen = false;
     app.toggleNav();
-    tick();
     expect(app.isNavOpen).toBeTrue();
     expect(fitSpy).toHaveBeenCalled();
 
     fitSpy.calls.reset();
     app.closeNav();
-    tick();
     expect(app.isNavOpen).toBeFalse();
     expect(fitSpy).toHaveBeenCalled();
   }));
@@ -135,6 +128,18 @@ describe('AppComponent', () => {
 
     expect((app as any).dragDepth).toBe(0);
     expect(app.showDropOverlay).toBeFalse();
+  });
+
+  it('detects when drag events contain files', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+
+    expect((app as any).containsFiles({} as unknown as DragEvent)).toBeFalse();
+    expect(
+      (app as any).containsFiles({
+        dataTransfer: { types: ['Files'] },
+      } as unknown as DragEvent)
+    ).toBeTrue();
   });
 
   it('calls saveForms when saving and resets showSave', async () => {

--- a/src/app/viewer/viewer.component.html
+++ b/src/app/viewer/viewer.component.html
@@ -1,5 +1,5 @@
 @if (htmlContent) {
-<div #contentContainer>
+<div #contentContainer (input)="onFormInteraction()" (change)="onFormInteraction()">
   <div [innerHTML]="htmlContent"></div>
 </div>
 }


### PR DESCRIPTION
## Summary
- switch AppComponent and ViewerComponent to OnPush change detection while reacting to resize events deterministically
- replace setTimeout-driven form listener attachment with bubbled form interaction events from the viewer
- adjust specs to cover drag/drop detection and new layout handling

## Testing
- npm test -- --watch=false --progress=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692615a66c4c832b9089d187567e798e)