### PR TITLE
Add Supabase email auth to navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-browser-dynamic": "^20.3.13",
         "@angular/router": "^20.3.13",
         "@angular/service-worker": "^20.3.13",
+        "@supabase/supabase-js": "^2.86.0",
         "@talers/html-pages": "^0.5.5",
         "dompurify": "^3.3.0",
         "jsbarcode": "^3.12.1",
@@ -5430,6 +5431,86 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.86.0.tgz",
+      "integrity": "sha512-3xPqMvBWC6Haqpr6hEWmSUqDq+6SA1BAEdbiaHdAZM9QjZ5uiQJ+6iD9pZOzOa6MVXZh4GmwjhC9ObIG0K1NcA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.86.0.tgz",
+      "integrity": "sha512-AlOoVfeaq9XGlBFIyXTmb+y+CZzxNO4wWbfgRM6iPpNU5WCXKawtQYSnhivi3UVxS7GA0rWovY4d6cIAxZAojA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.86.0.tgz",
+      "integrity": "sha512-QVf+wIXILcZJ7IhWhWn+ozdf8B+oO0Ulizh2AAPxD/6nQL+x3r9lJ47a+fpc/jvAOGXMbkeW534Kw6jz7e8iIA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.86.0.tgz",
+      "integrity": "sha512-dyS8bFoP29R/sj5zLi0AP3JfgG8ar1nuImcz5jxSx7UIW7fbFsXhUCVrSY2Ofo0+Ev6wiATiSdBOzBfWaiFyPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.86.0.tgz",
+      "integrity": "sha512-PM47jX/Mfobdtx7NNpoj9EvlrkapAVTQBZgGGslEXD6NS70EcGjhgRPBItwHdxZPM5GwqQ0cGMN06uhjeY2mHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.86.0.tgz",
+      "integrity": "sha512-BaC9sv5+HGNy1ulZwY8/Ev7EjfYYmWD4fOMw9bDBqTawEj6JHAiOHeTwXLRzVaeSay4p17xYLN2NSCoGgXMQnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.86.0",
+        "@supabase/functions-js": "2.86.0",
+        "@supabase/postgrest-js": "2.86.0",
+        "@supabase/realtime-js": "2.86.0",
+        "@supabase/storage-js": "2.86.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@talers/html-pages": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@talers/html-pages/-/html-pages-0.5.5.tgz",
@@ -5640,7 +5721,6 @@
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -5655,6 +5735,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
@@ -5751,7 +5837,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9188,6 +9273,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.18"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.0.tgz",
+      "integrity": "sha512-kmgmea2nguZEvRqW79gDqNXyxA3OS5WIgMVffrHpqXV4F/J4UmNIw2vstixioLTNSkd5rFB8G0s3Lwzogm6OFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -14839,7 +14933,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser-dynamic": "^20.3.13",
     "@angular/router": "^20.3.13",
     "@angular/service-worker": "^20.3.13",
+    "@supabase/supabase-js": "^2.86.0",
     "@talers/html-pages": "^0.5.5",
     "dompurify": "^3.3.0",
     "jsbarcode": "^3.12.1",

--- a/src/app/config/supabase.config.ts
+++ b/src/app/config/supabase.config.ts
@@ -1,0 +1,9 @@
+export const supabaseConfig = {
+  url: 'https://wqieplruslupjlxfpeqq.supabase.co',
+  anonKey:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndxaWVwbHJ1c2x1cGpseGZwZXFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQwNDAwOTQsImV4cCI6MjA3OTYxNjA5NH0.RsR3rjdOa5KYFh5ew-5l4AZjQxxgXEpb4m9tY7da6po',
+  redirectUrls: {
+    local: 'http://localhost:4200',
+    production: 'https://app.wdoc.info',
+  },
+};

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -51,6 +51,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 1 1 auto;
 }
 
 .nav-btn {
@@ -63,8 +64,24 @@
   font-weight: 600;
 }
 
+.auth-btn {
+  width: 100%;
+}
+
+.logout-btn {
+  margin-top: 0.75rem;
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 .nav-btn:focus-visible,
-.save-btn:focus-visible {
+.save-btn:focus-visible,
+.logout-btn:focus-visible,
+.modal-close:focus-visible {
   outline: 2px solid #76c7ff;
   outline-offset: 2px;
 }
@@ -89,6 +106,88 @@
   cursor: pointer;
   color: #fff;
   font-weight: 600;
+}
+
+.nav-footer {
+  padding: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  color: #1f1f1f;
+  width: min(480px, 100%);
+  border-radius: 8px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+  padding: 1rem 1.25rem;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.input-label {
+  font-weight: 600;
+}
+
+.modal-input {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.status-message {
+  margin: 0;
+  color: #2563eb;
+  font-size: 0.95rem;
+}
+
+.modal-actions {
+  margin-top: 1rem;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.hint {
+  margin: 0.75rem 0 0;
+  color: #555;
+  font-size: 0.9rem;
 }
 
 @media (min-width: 992px) {

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -66,16 +66,18 @@
 
 .auth-btn {
   width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
-.logout-btn {
-  margin-top: 0.75rem;
-  background: transparent;
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
+.auth-label {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .nav-btn:focus-visible,
@@ -174,6 +176,11 @@
   margin: 0;
   color: #2563eb;
   font-size: 0.95rem;
+}
+
+.user-email {
+  margin: 0;
+  font-weight: 600;
 }
 
 .modal-actions {

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -26,4 +26,55 @@
       tabindex="-1"
     />
   </div>
+  <footer class="nav-footer">
+    <button type="button" class="nav-btn auth-btn" (click)="openAuthModal()">
+      {{ currentUserEmail || 'Login / Sign up' }}
+    </button>
+    <button
+      *ngIf="currentUserEmail"
+      type="button"
+      class="logout-btn"
+      (click)="onLogout()"
+      [disabled]="isSubmitting"
+    >
+      Log out
+    </button>
+  </footer>
+
+  <div class="modal-backdrop" *ngIf="isAuthModalOpen" (click)="closeAuthModal()">
+    <div class="modal" role="dialog" aria-modal="true" (click)="$event.stopPropagation()">
+      <div class="modal-header">
+        <h3 class="modal-title">Login or sign up</h3>
+        <button type="button" class="modal-close" (click)="closeAuthModal()" aria-label="Close dialog">
+          &times;
+        </button>
+      </div>
+      <div class="modal-body">
+        <label class="input-label" for="auth-email">Email address</label>
+        <input
+          id="auth-email"
+          name="email"
+          type="email"
+          [(ngModel)]="email"
+          class="modal-input"
+          placeholder="you@example.com"
+          required
+        />
+        <p class="status-message" *ngIf="statusMessage">{{ statusMessage }}</p>
+      </div>
+      <div class="modal-actions">
+        <button
+          type="button"
+          class="nav-btn full-width"
+          (click)="onAuthSubmit()"
+          [disabled]="isSubmitting"
+        >
+          {{ isSubmitting ? 'Sending...' : 'Send login link' }}
+        </button>
+      </div>
+      <p class="hint">
+        We will send a login or signup link to your email.
+      </p>
+    </div>
+  </div>
 </aside>

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -28,16 +28,7 @@
   </div>
   <footer class="nav-footer">
     <button type="button" class="nav-btn auth-btn" (click)="openAuthModal()">
-      {{ currentUserEmail || 'Login / Sign up' }}
-    </button>
-    <button
-      *ngIf="currentUserEmail"
-      type="button"
-      class="logout-btn"
-      (click)="onLogout()"
-      [disabled]="isSubmitting"
-    >
-      Log out
+      <span class="auth-label">{{ currentUserEmail || 'Login / Sign up' }}</span>
     </button>
   </footer>
 
@@ -50,19 +41,24 @@
         </button>
       </div>
       <div class="modal-body">
-        <label class="input-label" for="auth-email">Email address</label>
-        <input
-          id="auth-email"
-          name="email"
-          type="email"
-          [(ngModel)]="email"
-          class="modal-input"
-          placeholder="you@example.com"
-          required
-        />
-        <p class="status-message" *ngIf="statusMessage">{{ statusMessage }}</p>
+        <ng-container *ngIf="!emailSent; else emailSentTemplate">
+          <label class="input-label" for="auth-email">Email address</label>
+          <input
+            id="auth-email"
+            name="email"
+            type="email"
+            [(ngModel)]="email"
+            class="modal-input"
+            placeholder="you@example.com"
+            required
+          />
+          <p class="status-message" *ngIf="statusMessage">{{ statusMessage }}</p>
+        </ng-container>
+        <ng-template #emailSentTemplate>
+          <p class="status-message">{{ statusMessage }}</p>
+        </ng-template>
       </div>
-      <div class="modal-actions">
+      <div class="modal-actions" *ngIf="!emailSent">
         <button
           type="button"
           class="nav-btn full-width"
@@ -72,9 +68,38 @@
           {{ isSubmitting ? 'Sending...' : 'Send login link' }}
         </button>
       </div>
-      <p class="hint">
+      <p class="hint" *ngIf="!emailSent">
         We will send a login or signup link to your email.
       </p>
+    </div>
+  </div>
+
+  <div class="modal-backdrop" *ngIf="isSettingsModalOpen" (click)="closeSettingsModal()">
+    <div class="modal" role="dialog" aria-modal="true" (click)="$event.stopPropagation()">
+      <div class="modal-header">
+        <h3 class="modal-title">Account settings</h3>
+        <button
+          type="button"
+          class="modal-close"
+          (click)="closeSettingsModal()"
+          aria-label="Close dialog"
+        >
+          &times;
+        </button>
+      </div>
+      <div class="modal-body">
+        <p class="user-email" *ngIf="currentUserEmail">{{ currentUserEmail }}</p>
+      </div>
+      <div class="modal-actions">
+        <button
+          type="button"
+          class="nav-btn full-width"
+          (click)="onLogout()"
+          [disabled]="isSubmitting"
+        >
+          Log out
+        </button>
+      </div>
     </div>
   </div>
 </aside>

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -54,12 +54,21 @@ describe('NavbarComponent', () => {
 
   it('should open auth modal with stored email and clear status', () => {
     authService.getStoredEmail.and.returnValue('stored@example.com');
-    component.currentUserEmail = authService.getStoredEmail();
     component.openAuthModal();
 
     expect(component.isAuthModalOpen).toBeTrue();
     expect(component.email).toBe('stored@example.com');
     expect(component.statusMessage).toBe('');
+    expect(component.emailSent).toBeFalse();
+  });
+
+  it('should open settings modal when user already logged in', () => {
+    component.currentUserEmail = 'user@example.com';
+
+    component.openAuthModal();
+
+    expect(component.isSettingsModalOpen).toBeTrue();
+    expect(component.isAuthModalOpen).toBeFalse();
   });
 
   it('should show validation message when no email provided', async () => {
@@ -84,19 +93,21 @@ describe('NavbarComponent', () => {
     expect(component.isSubmitting).toBeFalse();
   });
 
-  it('should set status when sign in succeeds', async () => {
+  it('should set status when sign in succeeds and hide input', async () => {
     component.email = 'user@example.com';
 
     await component.onAuthSubmit();
 
     expect(authService.signInWithEmail).toHaveBeenCalledWith('user@example.com');
-    expect(component.statusMessage).toContain('Check your email');
+    expect(component.statusMessage).toContain('Please check your email');
     expect(component.currentUserEmail).toBe('user@example.com');
     expect(component.isSubmitting).toBeFalse();
+    expect(component.emailSent).toBeTrue();
   });
 
   it('should clear auth state on logout', async () => {
     component.currentUserEmail = 'user@example.com';
+    component.isSettingsModalOpen = true;
 
     await component.onLogout();
 
@@ -104,6 +115,7 @@ describe('NavbarComponent', () => {
     expect(component.currentUserEmail).toBeNull();
     expect(component.statusMessage).toBe('');
     expect(component.isSubmitting).toBeFalse();
+    expect(component.isSettingsModalOpen).toBeFalse();
   });
 
   it('should update current user when session changes', () => {

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -4,20 +4,25 @@ import { NavbarComponent } from './navbar.component';
 import { AuthService } from '../services/auth.service';
 
 class MockAuthService {
-  private sessionSubject = new BehaviorSubject(null);
+  private sessionSubject = new BehaviorSubject<any>(null);
   session$ = this.sessionSubject.asObservable();
   getStoredEmail = jasmine.createSpy('getStoredEmail').and.returnValue(null);
   signInWithEmail = jasmine
     .createSpy('signInWithEmail')
-    .and.returnValue(Promise.resolve({ error: null }));
+    .and.callFake(() => Promise.resolve({ error: null }));
   signOut = jasmine
     .createSpy('signOut')
-    .and.returnValue(Promise.resolve({ error: null }));
+    .and.callFake(() => Promise.resolve({ error: null }));
+
+  emitSession(session: unknown) {
+    this.sessionSubject.next(session);
+  }
 }
 
 describe('NavbarComponent', () => {
   let fixture: ComponentFixture<NavbarComponent>;
   let component: NavbarComponent;
+  let authService: MockAuthService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -27,6 +32,7 @@ describe('NavbarComponent', () => {
 
     fixture = TestBed.createComponent(NavbarComponent);
     component = fixture.componentInstance;
+    authService = TestBed.inject(AuthService) as unknown as MockAuthService;
     fixture.detectChanges();
   });
 
@@ -44,5 +50,64 @@ describe('NavbarComponent', () => {
 
     expect(emitted).toBeTruthy();
     expect(emitted!.name).toBe('test.zip');
+  });
+
+  it('should open auth modal with stored email and clear status', () => {
+    authService.getStoredEmail.and.returnValue('stored@example.com');
+    component.currentUserEmail = authService.getStoredEmail();
+    component.openAuthModal();
+
+    expect(component.isAuthModalOpen).toBeTrue();
+    expect(component.email).toBe('stored@example.com');
+    expect(component.statusMessage).toBe('');
+  });
+
+  it('should show validation message when no email provided', async () => {
+    component.email = '';
+    await component.onAuthSubmit();
+
+    expect(component.statusMessage).toContain('Please enter your email');
+    expect(authService.signInWithEmail).not.toHaveBeenCalled();
+    expect(component.isSubmitting).toBeFalse();
+  });
+
+  it('should display error when sign in fails', async () => {
+    const error = { message: 'failed' };
+    authService.signInWithEmail.and.returnValue(Promise.resolve({ error } as any));
+    component.email = 'user@example.com';
+
+    await component.onAuthSubmit();
+
+    expect(authService.signInWithEmail).toHaveBeenCalledWith('user@example.com');
+    expect(component.statusMessage).toBe('failed');
+    expect(component.currentUserEmail).toBeNull();
+    expect(component.isSubmitting).toBeFalse();
+  });
+
+  it('should set status when sign in succeeds', async () => {
+    component.email = 'user@example.com';
+
+    await component.onAuthSubmit();
+
+    expect(authService.signInWithEmail).toHaveBeenCalledWith('user@example.com');
+    expect(component.statusMessage).toContain('Check your email');
+    expect(component.currentUserEmail).toBe('user@example.com');
+    expect(component.isSubmitting).toBeFalse();
+  });
+
+  it('should clear auth state on logout', async () => {
+    component.currentUserEmail = 'user@example.com';
+
+    await component.onLogout();
+
+    expect(authService.signOut).toHaveBeenCalled();
+    expect(component.currentUserEmail).toBeNull();
+    expect(component.statusMessage).toBe('');
+    expect(component.isSubmitting).toBeFalse();
+  });
+
+  it('should update current user when session changes', () => {
+    authService.emitSession({ user: { email: 'session@example.com' } } as any);
+    expect(component.currentUserEmail).toBe('session@example.com');
   });
 });

--- a/src/app/navbar/navbar.component.spec.ts
+++ b/src/app/navbar/navbar.component.spec.ts
@@ -1,5 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
 import { NavbarComponent } from './navbar.component';
+import { AuthService } from '../services/auth.service';
+
+class MockAuthService {
+  private sessionSubject = new BehaviorSubject(null);
+  session$ = this.sessionSubject.asObservable();
+  getStoredEmail = jasmine.createSpy('getStoredEmail').and.returnValue(null);
+  signInWithEmail = jasmine
+    .createSpy('signInWithEmail')
+    .and.returnValue(Promise.resolve({ error: null }));
+  signOut = jasmine
+    .createSpy('signOut')
+    .and.returnValue(Promise.resolve({ error: null }));
+}
 
 describe('NavbarComponent', () => {
   let fixture: ComponentFixture<NavbarComponent>;
@@ -8,10 +22,12 @@ describe('NavbarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NavbarComponent],
+      providers: [{ provide: AuthService, useClass: MockAuthService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavbarComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   it('should create', () => {

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -28,6 +28,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
   @ViewChild('fileInput') fileInput?: ElementRef<HTMLInputElement>;
 
   isAuthModalOpen = false;
+  isSettingsModalOpen = false;
+  emailSent = false;
   email = '';
   statusMessage = '';
   isSubmitting = false;
@@ -63,13 +65,26 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   openAuthModal() {
+    if (this.currentUserEmail) {
+      this.isSettingsModalOpen = true;
+      return;
+    }
     this.isAuthModalOpen = true;
     this.statusMessage = '';
-    this.email = this.currentUserEmail ?? '';
+    this.emailSent = false;
+    this.email =
+      this.currentUserEmail ?? this.authService.getStoredEmail() ?? '';
   }
 
   closeAuthModal() {
     this.isAuthModalOpen = false;
+    this.isSubmitting = false;
+    this.emailSent = false;
+    this.statusMessage = '';
+  }
+
+  closeSettingsModal() {
+    this.isSettingsModalOpen = false;
   }
 
   async onAuthSubmit() {
@@ -86,7 +101,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
       return;
     }
     this.currentUserEmail = this.email;
-    this.statusMessage = 'Check your email to complete sign in or sign up.';
+    this.statusMessage = 'Please check your email.';
+    this.emailSent = true;
   }
 
   async onLogout() {
@@ -95,5 +111,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.isSubmitting = false;
     this.currentUserEmail = null;
     this.statusMessage = '';
+    this.email = '';
+    this.isSettingsModalOpen = false;
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@angular/core';
+import { createClient, Session, SupabaseClient } from '@supabase/supabase-js';
+import { BehaviorSubject } from 'rxjs';
+import { supabaseConfig } from '../config/supabase.config';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly supabase: SupabaseClient;
+  private readonly emailStorageKey = 'wdoc-auth-email';
+  private sessionSubject = new BehaviorSubject<Session | null>(null);
+  session$ = this.sessionSubject.asObservable();
+
+  constructor() {
+    this.supabase = createClient(supabaseConfig.url, supabaseConfig.anonKey);
+    void this.loadInitialSession();
+
+    this.supabase.auth.onAuthStateChange((_event, session) => {
+      this.sessionSubject.next(session);
+      const email = session?.user?.email;
+      if (email) {
+        this.saveEmail(email);
+      } else {
+        this.clearEmail();
+      }
+    });
+  }
+
+  async loadInitialSession() {
+    const { data } = await this.supabase.auth.getSession();
+    const session = data.session ?? null;
+    this.sessionSubject.next(session);
+    const email = session?.user?.email;
+    if (email) {
+      this.saveEmail(email);
+    }
+  }
+
+  async signInWithEmail(email: string) {
+    const redirectTo = this.getRedirectUrl();
+    this.saveEmail(email);
+    return this.supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: redirectTo,
+      },
+    });
+  }
+
+  async signOut() {
+    this.clearEmail();
+    return this.supabase.auth.signOut();
+  }
+
+  getStoredEmail(): string | null {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    return localStorage.getItem(this.emailStorageKey);
+  }
+
+  private saveEmail(email: string) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    localStorage.setItem(this.emailStorageKey, email);
+  }
+
+  private clearEmail() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    localStorage.removeItem(this.emailStorageKey);
+  }
+
+  private getRedirectUrl() {
+    if (typeof window === 'undefined') {
+      return supabaseConfig.redirectUrls.production;
+    }
+    if (window.location.origin.includes('localhost')) {
+      return supabaseConfig.redirectUrls.local;
+    }
+    return supabaseConfig.redirectUrls.production;
+  }
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { createClient, Session, SupabaseClient } from '@supabase/supabase-js';
+import { Session, SupabaseClient } from '@supabase/supabase-js';
 import { BehaviorSubject } from 'rxjs';
 import { supabaseConfig } from '../config/supabase.config';
+import { getSupabaseClient } from './supabase-client';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -11,7 +12,7 @@ export class AuthService {
   session$ = this.sessionSubject.asObservable();
 
   constructor() {
-    this.supabase = createClient(supabaseConfig.url, supabaseConfig.anonKey);
+    this.supabase = getSupabaseClient();
     void this.loadInitialSession();
 
     this.supabase.auth.onAuthStateChange((_event, session) => {

--- a/src/app/services/supabase-client.ts
+++ b/src/app/services/supabase-client.ts
@@ -1,0 +1,16 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { supabaseConfig } from '../config/supabase.config';
+
+let supabase: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+  if (!supabase) {
+    supabase = createClient(supabaseConfig.url, supabaseConfig.anonKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+  }
+  return supabase;
+}

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -58,7 +58,7 @@
         </button>
         @if (attachmentsMenuOpen) {
           <div class="attachments-dropdown" role="menu">
-            @if (attachments?.length) {
+            @if (attachments.length) {
               <div class="attachments-section">
                 <div class="section-title">Attachment(s)</div>
                 <ul>
@@ -72,7 +72,7 @@
                 </ul>
               </div>
             }
-            @if (formAnswers?.length) {
+            @if (formAnswers.length) {
               <div class="attachments-section">
                 <div class="section-title">Form answers</div>
                 <ul>


### PR DESCRIPTION
## Summary
- add Supabase configuration and client service for email magic link authentication
- extend the navbar with login/signup modal, status messaging, and logout handling
- add Supabase dependency and update navbar tests to use an auth service stub

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless --progress=false *(fails: ChromeHeadless cannot start without --no-sandbox when running as root)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6928b5998ac0832bbe12abde008d245e)