### PR TITLE
Add tiptap editor for new document creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@angular/service-worker": "^20.3.13",
         "@supabase/supabase-js": "^2.86.0",
         "@talers/html-pages": "^0.5.5",
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/starter-kit": "^3.11.1",
         "dompurify": "^3.3.0",
         "jsbarcode": "^3.12.1",
         "jszip": "^3.10.1",
@@ -5019,6 +5021,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
@@ -5516,6 +5524,379 @@
       "resolved": "https://registry.npmjs.org/@talers/html-pages/-/html-pages-0.5.5.tgz",
       "integrity": "sha512-yIasj9HqO/IN/n+TxyvgMXxMro0Sn6pmIf0AgAhsF/jdpr+dXctiNuv17F0AWxz1iqa2mVh5j7nwREZ4bMFz6A=="
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.11.1.tgz",
+      "integrity": "sha512-q7uzYrCq40JOIi6lceWe2HuA8tSr97iPwP/xtJd0bZjyL1rWhUyqxMb7y+aq4RcELrx/aNRa2JIvLtRRdy02Dg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.11.1.tgz",
+      "integrity": "sha512-c3DN5c/9kl8w1wCcylH9XqW0OyCegqE3EL4rDlVYkyBD0GwCnUS30pN+jdxCUq/tl94lkkRk7XMyEUwzQmG+5g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.11.1.tgz",
+      "integrity": "sha512-ee/OoAPViUAgJb8dxF7D2YSSYUWcw8RXqhNSDx15w58rxpYbJbvOv3WDMrGNvl4M9nuwXYfXc3iPl/eYtwHx2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.11.1.tgz",
+      "integrity": "sha512-6fj0b0Ynam8FMsP3NiCZ4a2uP7lCBHDFBXfcRwFDOqAgBIPvIK+r6CuHEGothGaF7EeQ9MTyj9fwlGjyHsPQcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.11.1.tgz",
+      "integrity": "sha512-R3HtNPAuaKqbDwK1uWO/6QFHXbbKcxbV27XVCVtTQ4gCAzIZbJElp9REEqAOp/zI6bqt774UrAekeV+5i8NQYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.11.1.tgz",
+      "integrity": "sha512-Bk7mmA+m510zzLG5AMFmywrL50NlBA5p7bR0cKfdp4ckXr8FohxH3QS0Woy1MRnFUGRtIzJkSYQTJ3O/G1lBqQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/pm": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.11.1.tgz",
+      "integrity": "sha512-Px8T7Kv8EEiFpM/h13Rro8HoynrlK8zA3u3ekHq/FBSTXnPtqPAUYNx/DUhIrLs3eWWJ8+P0Onm+sVLZmaLMug==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.11.1.tgz",
+      "integrity": "sha512-+tmWD/4tg7Mt1TArrvc1Gna1FiSyru2rE6sapEerXCH3RFfaqGBeMqeRaOeZrCiqB+vIsXfthHDC/7xz5rFp/g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.11.1.tgz",
+      "integrity": "sha512-rZ4eIFOPrLPM0bAMW560v/i9WeAz6D6PPtmFJ/Rwh7F5QFbg+jSXAyGvg7V9ZwzA5OaXqsToyJBR7qtGXBXAhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.11.1.tgz",
+      "integrity": "sha512-JMp6CizdB7LoY2jmaZub2D+Aj6RJTkSu0EhIcN/bmBrm4MjYa/ir6nRoo4/gYGIHzHwgwGR/1KmlqTJZW/xl4g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.11.1.tgz",
+      "integrity": "sha512-b9ShCSQhWXNzdbdn9a3j33cq646nS0EpVyNBQr0BMOpIcMI4Ot8LGEvPo0BNqPPvpjMJaP2N6xp+EIdk6tunfQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.11.1.tgz",
+      "integrity": "sha512-9zr6dItcJvzZtFlC+dyFb5VfWGzKzldPAOuln1d/GwKrBZds53O2vBmu4Jxfy22N9LuwiGB+2PYerq0UkLnxnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/pm": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.11.1.tgz",
+      "integrity": "sha512-SrjsU+gvhjoPKelc4YSeC2AQ0lhwLiDWMO7fW83CVitCF8iWXpBSeVCI5SxtPeZNKTZ1ZCc3lIQCeEHOC/gP0g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.11.1.tgz",
+      "integrity": "sha512-ds5auQnWGcHwC2/c1iEvvybdLPcSDlxsii7FPaZg4LaSGdNojRB0qDRZw5dzYQZbfIf5vgYGcIVCVjNPZs1UwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/pm": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.11.1.tgz",
+      "integrity": "sha512-XJRN9pOPMi3SsaKv4qM8WBEi3YDrjXYtYlAlZutQe1JpdKykSjLwwYq7k3V8UHqR3YKxyOV8HTYOYoOaZ9TMTQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/pm": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.11.1.tgz",
+      "integrity": "sha512-KFw3TAwN6hQ+oDeE3lRqwzCRKhxU1NWf9q5SAwiUxlp/LcEjuhXcYJYX8SHPOLOlTo0P42v1i0KBeLUPKnO58g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.11.1.tgz",
+      "integrity": "sha512-MpeuVi+bOHulbN65bOjaeoNJstNuAAEPdLwNjW25c9y2a8b5iZFY8vdVNENDiqq+dI+F5EaFGaEq0FN0uslfiA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.11.1.tgz",
+      "integrity": "sha512-Aphq0kfk6J/hNQennJ+bntvDzqRPT7RVpnow1s4U4dLBsR6PP7X4zEBg96uAv2OW0RjDHFK9NFqpJPbZtQTmFw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.11.1.tgz",
+      "integrity": "sha512-a3lm1WvYewAP2IESq+qnbOtLSJ9yULY2Bj/6DvBq9fzWpb2gSlUdElYh6JLunxB1HEPECTuuRsNPdTrMsSpV4g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.11.1.tgz",
+      "integrity": "sha512-1LfkHNkrGR509cPRgcMr95+nWcAHE0JDm9LkuzdexunhCfJ2tl/h1rA14x3sic8GxQFqEnMefvBUpUbQwPydYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.11.1.tgz",
+      "integrity": "sha512-5E94ggkFAZ7OSFSwnofAsmxqmSStRoeCB8AnRuWrR+nnXi43Rq7yptdejQaLi13Z9fSVdnF6h+pB3ua2Exg6WQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.11.1.tgz",
+      "integrity": "sha512-Y3EJxfE1g4XSGbUZN+74o38mp3O+BQXtlqxAQvedzXiGGrdK2kWhp2b4nj3IkxHdRdoSijf+oZzgyBrRDdgC/w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.11.1.tgz",
+      "integrity": "sha512-/xXJdV+EVvSQv2slvAUChb5iGVv5K0EqBqxPGAAuBHdIc4Y7Id1aaKKSiyDmqon+kjSnnQIIda9oUt+o/Z66uA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/pm": "^3.11.1"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.11.1.tgz",
+      "integrity": "sha512-8RIUhlEoCFGsbdNb+EUdQctG1Wnd7rl4wlMLS6giO7UcZT5dVfg625eMZVrl0/kA7JBJdKLIuqNmzzQ0MxsJEw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.11.1.tgz",
+      "integrity": "sha512-weRrhp0p5J6cMNcybYobhbOVrgym7KYIwBblJ/1M1snykg+avZawVk2M5Y7j9gM1p2zo112MCw8z8nOa9Yrwow==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/extension-blockquote": "^3.11.1",
+        "@tiptap/extension-bold": "^3.11.1",
+        "@tiptap/extension-bullet-list": "^3.11.1",
+        "@tiptap/extension-code": "^3.11.1",
+        "@tiptap/extension-code-block": "^3.11.1",
+        "@tiptap/extension-document": "^3.11.1",
+        "@tiptap/extension-dropcursor": "^3.11.1",
+        "@tiptap/extension-gapcursor": "^3.11.1",
+        "@tiptap/extension-hard-break": "^3.11.1",
+        "@tiptap/extension-heading": "^3.11.1",
+        "@tiptap/extension-horizontal-rule": "^3.11.1",
+        "@tiptap/extension-italic": "^3.11.1",
+        "@tiptap/extension-link": "^3.11.1",
+        "@tiptap/extension-list": "^3.11.1",
+        "@tiptap/extension-list-item": "^3.11.1",
+        "@tiptap/extension-list-keymap": "^3.11.1",
+        "@tiptap/extension-ordered-list": "^3.11.1",
+        "@tiptap/extension-paragraph": "^3.11.1",
+        "@tiptap/extension-strike": "^3.11.1",
+        "@tiptap/extension-text": "^3.11.1",
+        "@tiptap/extension-underline": "^3.11.1",
+        "@tiptap/extensions": "^3.11.1",
+        "@tiptap/pm": "^3.11.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -5708,6 +6089,28 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -7509,6 +7912,12 @@
         }
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8113,7 +8522,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -8284,6 +8692,18 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -10633,6 +11053,21 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/listr2": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.1.tgz",
@@ -10935,6 +11370,23 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -10944,6 +11396,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -11959,6 +12417,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -12637,6 +13101,201 @@
         "node": ">=10"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.3.1.tgz",
+      "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.0.tgz",
+      "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
+      "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.1.tgz",
+      "integrity": "sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.25.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-transform": "^1.10.3",
+        "prosemirror-view": "^1.39.1"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
+      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
+      "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12709,6 +13368,15 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/puppeteer": {
       "version": "24.31.0",
@@ -13338,6 +14006,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.52.3",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -14929,6 +15603,12 @@
         "node": "*"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -15249,6 +15929,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/watchpack": {
       "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@angular/service-worker": "^20.3.13",
     "@supabase/supabase-js": "^2.86.0",
     "@talers/html-pages": "^0.5.5",
+    "@tiptap/core": "^3.11.1",
+    "@tiptap/starter-kit": "^3.11.1",
     "dompurify": "^3.3.0",
     "jsbarcode": "^3.12.1",
     "jszip": "^3.10.1",

--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -16,22 +16,31 @@
   <mat-sidenav-content>
     <div class="main-content">
       <app-topbar
-        [showSave]="showSave"
+        [showSave]="isEditing || showSave"
         [navOpen]="isNavOpen"
         [title]="documentTitle"
         [zoom]="zoom"
-        [hasDocument]="!!htmlContent"
+        [hasDocument]="!isEditing && !!htmlContent"
         [attachments]="attachments"
         [formAnswers]="formAnswers"
+        [showNewDocument]="true"
         (toggleNav)="toggleNav()"
-        (save)="onSaveForms()"
+        (save)="isEditing ? onSaveNewDocument() : onSaveForms()"
         (zoomChange)="onZoomChange($event)"
+        (createNewDocument)="startNewDocument()"
       ></app-topbar>
-      <app-viewer
-        [htmlContent]="htmlContent"
-        [zoom]="zoom"
-        (formInteraction)="onFormInteraction()"
-      ></app-viewer>
+      @if (isEditing) {
+        <app-document-editor
+          [content]="editorContent"
+          (contentChange)="onEditorContentChange($event)"
+        ></app-document-editor>
+      } @else {
+        <app-viewer
+          [htmlContent]="htmlContent"
+          [zoom]="zoom"
+          (formInteraction)="onFormInteraction()"
+        ></app-viewer>
+      }
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -5,12 +5,14 @@ import { FormManagerService } from '../services/form-manager.service';
 import { HtmlProcessingService } from '../services/html-processing.service';
 import { WdocLoaderService } from '../services/wdoc-loader.service';
 import { DialogService } from '../services/dialog.service';
+import { DocumentCreatorService } from '../services/document-creator.service';
 
 describe('AppComponent', () => {
   let formManager: jasmine.SpyObj<FormManagerService>;
   let wdocLoader: jasmine.SpyObj<WdocLoaderService>;
   let htmlProcessor: jasmine.SpyObj<HtmlProcessingService>;
   let dialogService: jasmine.SpyObj<DialogService>;
+  let documentCreator: jasmine.SpyObj<DocumentCreatorService>;
 
   beforeEach(async () => {
     formManager = jasmine.createSpyObj('FormManagerService', ['saveForms']);
@@ -20,6 +22,9 @@ describe('AppComponent', () => {
     htmlProcessor = jasmine.createSpyObj('HtmlProcessingService', ['cleanup']);
     dialogService = jasmine.createSpyObj('DialogService', ['openAlert']);
     dialogService.openAlert.and.resolveTo();
+    documentCreator = jasmine.createSpyObj('DocumentCreatorService', [
+      'downloadWdocFromHtml',
+    ]);
 
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, AppComponent],
@@ -28,6 +33,7 @@ describe('AppComponent', () => {
         { provide: WdocLoaderService, useValue: wdocLoader },
         { provide: HtmlProcessingService, useValue: htmlProcessor },
         { provide: DialogService, useValue: dialogService },
+        { provide: DocumentCreatorService, useValue: documentCreator },
       ],
     }).compileComponents();
   });
@@ -155,6 +161,16 @@ describe('AppComponent', () => {
 
     expect(formManager.saveForms).toHaveBeenCalledWith(container, buffer);
     expect(app.showSave).toBeFalse();
+  });
+
+  it('creates a new document and triggers a download on save', async () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+    app.startNewDocument();
+    await app.onSaveNewDocument();
+
+    expect(app.isEditing).toBeTrue();
+    expect(documentCreator.downloadWdocFromHtml).toHaveBeenCalled();
   });
 
   it('handles dragenter/leave to toggle overlay depth', () => {

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -23,6 +23,8 @@ import {
   WdocLoaderService,
 } from '../services/wdoc-loader.service';
 import { DialogService } from '../services/dialog.service';
+import { DocumentEditorComponent } from '../editor/document-editor.component';
+import { DocumentCreatorService } from '../services/document-creator.service';
 
 @Component({
   selector: 'app-root',
@@ -32,6 +34,7 @@ import { DialogService } from '../services/dialog.service';
     NavbarComponent,
     ViewerComponent,
     TopbarComponent,
+    DocumentEditorComponent,
     MatSidenavModule,
   ],
   templateUrl: './app.component.html',
@@ -42,13 +45,16 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   htmlContent: SafeHtml | null = null;
   showSave = false;
   isNavOpen = false;
+  isEditing = false;
   sidenavMode: MatDrawerMode = 'over';
   showDropOverlay = false;
   zoom = 100;
   private readonly defaultTitle = 'WDOC viewer';
+  private readonly newDocumentTitle = 'New document';
   private readonly minZoom = 25;
   private readonly maxZoom = 200;
   documentTitle = this.defaultTitle;
+  editorContent = '<p>Start writing...</p>';
   private originalArrayBuffer: ArrayBuffer | null = null;
   private resizeListener?: () => void;
   private isDesktop = false;
@@ -67,6 +73,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     private dialogService: DialogService,
     private cdr: ChangeDetectorRef,
     private zone: NgZone,
+    private documentCreatorService: DocumentCreatorService,
   ) {}
 
   attachments: LoadedFile[] = [];
@@ -342,6 +349,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     this.originalArrayBuffer = result.originalArrayBuffer;
     this.documentTitle = result.documentTitle;
+    this.isEditing = false;
     this.attachments = result.attachments;
     this.formAnswers = result.formAnswers;
     this.showSave = false;
@@ -355,5 +363,26 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   onFormInteraction(): void {
     this.showSave = true;
+  }
+
+  startNewDocument(): void {
+    this.isEditing = true;
+    this.documentTitle = this.newDocumentTitle;
+    this.editorContent = '<p>Start writing...</p>';
+    this.showSave = true;
+    this.cdr.markForCheck();
+  }
+
+  onEditorContentChange(content: string): void {
+    this.editorContent = content;
+    this.showSave = true;
+  }
+
+  async onSaveNewDocument(): Promise<void> {
+    const content = this.editorContent?.trim()
+      ? this.editorContent
+      : '<p></p>';
+    await this.documentCreatorService.downloadWdocFromHtml(content);
+    this.showSave = false;
   }
 }

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -319,8 +319,9 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
       return null;
     }
 
-    const pageElement = (this.viewer.nativeElement.querySelector('wdoc-page') ||
-      this.viewer.nativeElement.firstElementChild) as HTMLElement | null;
+    const root = this.viewer.documentRoot ?? this.viewer.nativeElement;
+    const pageElement = (root.querySelector('wdoc-page') ||
+      root.firstElementChild) as HTMLElement | null;
 
     if (!pageElement) {
       return null;

--- a/src/app/editor/document-editor.component.css
+++ b/src/app/editor/document-editor.component.css
@@ -1,0 +1,51 @@
+.editor-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: #f8fafc;
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+  min-height: calc(100vh - 96px);
+}
+
+.editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.editor-toolbar button {
+  border: 1px solid #d0d7de;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.editor-toolbar button:hover {
+  background: #eef2ff;
+}
+
+.editor-toolbar button.active {
+  background: #312e81;
+  color: #ffffff;
+  border-color: #312e81;
+}
+
+.editor-surface {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 18px 20px;
+  min-height: 420px;
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+.editor-surface:focus-within {
+  outline: 2px solid #4338ca;
+  outline-offset: 3px;
+}

--- a/src/app/editor/document-editor.component.html
+++ b/src/app/editor/document-editor.component.html
@@ -1,0 +1,23 @@
+<div class="editor-wrapper">
+  <div class="editor-toolbar" role="toolbar" aria-label="Editor tools">
+    <button type="button" (click)="toggleBold()" [class.active]="isActive('bold')">
+      Bold
+    </button>
+    <button type="button" (click)="toggleItalic()" [class.active]="isActive('italic')">
+      Italic
+    </button>
+    <button type="button" (click)="setHeading(2)" [class.active]="isActive('heading', { level: 2 })">
+      H2
+    </button>
+    <button type="button" (click)="setHeading(3)" [class.active]="isActive('heading', { level: 3 })">
+      H3
+    </button>
+    <button type="button" (click)="toggleBulletList()" [class.active]="isActive('bulletList')">
+      Bullet list
+    </button>
+    <button type="button" (click)="toggleOrderedList()" [class.active]="isActive('orderedList')">
+      Numbered list
+    </button>
+  </div>
+  <div #editorHost class="editor-surface" aria-label="Document content"></div>
+</div>

--- a/src/app/editor/document-editor.component.spec.ts
+++ b/src/app/editor/document-editor.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
+import { DocumentEditorComponent } from './document-editor.component';
+
+describe('DocumentEditorComponent', () => {
+  let fixture: ComponentFixture<DocumentEditorComponent>;
+  let component: DocumentEditorComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DocumentEditorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocumentEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('emits content changes when the document updates', () => {
+    const emitSpy = spyOn(component.contentChange, 'emit');
+    component.editor?.commands.setContent('<p>Updated</p>');
+    expect(emitSpy).toHaveBeenCalled();
+  });
+
+  it('updates the live document when the input content changes', () => {
+    component.content = '<p>Reset</p>';
+    component.ngOnChanges({
+      content: new SimpleChange(undefined, component.content, false),
+    });
+
+    expect(component.editor?.getHTML()).toContain('Reset');
+  });
+
+  it('exposes basic formatting commands', () => {
+    component.toggleBold();
+    component.toggleItalic();
+    component.toggleBulletList();
+    component.toggleOrderedList();
+    component.setHeading(2);
+
+    expect(component.editor?.isActive('heading', { level: 2 })).toBeTrue();
+  });
+});

--- a/src/app/editor/document-editor.component.ts
+++ b/src/app/editor/document-editor.component.ts
@@ -1,0 +1,82 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnChanges,
+  SimpleChanges,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Level } from '@tiptap/extension-heading';
+
+@Component({
+  selector: 'app-document-editor',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './document-editor.component.html',
+  styleUrls: ['./document-editor.component.css'],
+})
+export class DocumentEditorComponent
+  implements AfterViewInit, OnDestroy, OnChanges
+{
+  @Input() content = '<p>Start writing...</p>';
+  @Output() contentChange = new EventEmitter<string>();
+  @ViewChild('editorHost') editorHost?: ElementRef<HTMLElement>;
+
+  editor?: Editor;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (
+      changes['content'] &&
+      this.editor &&
+      typeof changes['content'].currentValue === 'string'
+    ) {
+      this.editor.commands.setContent(this.content, { emitUpdate: false });
+    }
+  }
+
+  ngAfterViewInit(): void {
+    if (this.editorHost) {
+      this.editor = new Editor({
+        element: this.editorHost.nativeElement,
+        extensions: [StarterKit],
+        content: this.content,
+        onUpdate: ({ editor }) => this.contentChange.emit(editor.getHTML()),
+      });
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.editor?.destroy();
+  }
+
+  toggleBold() {
+    this.editor?.chain().focus().toggleBold().run();
+  }
+
+  toggleItalic() {
+    this.editor?.chain().focus().toggleItalic().run();
+  }
+
+  toggleBulletList() {
+    this.editor?.chain().focus().toggleBulletList().run();
+  }
+
+  toggleOrderedList() {
+    this.editor?.chain().focus().toggleOrderedList().run();
+  }
+
+  setHeading(level: Level) {
+    this.editor?.chain().focus().toggleHeading({ level }).run();
+  }
+
+  isActive(name: string, attrs?: Record<string, unknown>) {
+    return this.editor?.isActive(name, attrs) ?? false;
+  }
+}

--- a/src/app/services/document-creator.service.spec.ts
+++ b/src/app/services/document-creator.service.spec.ts
@@ -1,0 +1,28 @@
+import { TestBed } from '@angular/core/testing';
+import JSZip from 'jszip';
+import { DocumentCreatorService } from './document-creator.service';
+
+describe('DocumentCreatorService', () => {
+  let service: DocumentCreatorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DocumentCreatorService);
+  });
+
+  it('builds a wdoc blob with an index and manifest entries', async () => {
+    const blob = await service.buildWdocBlob('<p>Draft</p>');
+    const arrayBuffer = await blob.arrayBuffer();
+    const zip = await JSZip.loadAsync(arrayBuffer);
+
+    const index = zip.file('index.html');
+    const manifest = zip.file('content_manifest.json');
+
+    expect(index).toBeTruthy();
+    expect(manifest).toBeTruthy();
+
+    const manifestJson = JSON.parse(await manifest!.async('text'));
+    const filePaths = manifestJson.files.map((f: any) => f.path);
+    expect(filePaths).toContain('index.html');
+  });
+});

--- a/src/app/services/document-creator.service.spec.ts
+++ b/src/app/services/document-creator.service.spec.ts
@@ -25,4 +25,14 @@ describe('DocumentCreatorService', () => {
     const filePaths = manifestJson.files.map((f: any) => f.path);
     expect(filePaths).toContain('index.html');
   });
+
+  it('scopes default styles to the document wrapper', async () => {
+    const blob = await service.buildWdocBlob('<p>Draft</p>');
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const indexContent = await zip.file('index.html')!.async('text');
+
+    expect(indexContent).toContain('class="wdoc-document"');
+    expect(indexContent).toContain('.wdoc-document h1');
+    expect(indexContent.includes('body {')).toBeFalse();
+  });
 });

--- a/src/app/services/document-creator.service.ts
+++ b/src/app/services/document-creator.service.ts
@@ -31,13 +31,15 @@ export class DocumentCreatorService {
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>WDOC document</title>
   <style>
-    body { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; margin: 32px; line-height: 1.6; }
-    h1, h2, h3, h4 { margin-top: 1.6em; }
-    p { margin: 0.8em 0; }
+    .wdoc-document { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; margin: 32px; line-height: 1.6; }
+    .wdoc-document h1, .wdoc-document h2, .wdoc-document h3, .wdoc-document h4 { margin-top: 1.6em; }
+    .wdoc-document p { margin: 0.8em 0; }
   </style>
 </head>
 <body>
+<div class="wdoc-document">
 ${content}
+</div>
 </body>
 </html>`;
   }

--- a/src/app/services/document-creator.service.ts
+++ b/src/app/services/document-creator.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@angular/core';
+import JSZip from 'jszip';
+import { WdocLoaderService } from './wdoc-loader.service';
+
+@Injectable({ providedIn: 'root' })
+export class DocumentCreatorService {
+  async downloadWdocFromHtml(html: string, filename = 'new-document.wdoc') {
+    const blob = await this.buildWdocBlob(html);
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }
+
+  async buildWdocBlob(html: string): Promise<Blob> {
+    const zip = new JSZip();
+    const wrapped = this.wrapHtml(html);
+    zip.file('index.html', wrapped);
+    zip.folder('wdoc-form');
+    const manifest = await this.generateContentManifest(zip);
+    zip.file('content_manifest.json', manifest);
+    return zip.generateAsync({ type: 'blob' });
+  }
+
+  private wrapHtml(content: string): string {
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WDOC document</title>
+  <style>
+    body { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; margin: 32px; line-height: 1.6; }
+    h1, h2, h3, h4 { margin-top: 1.6em; }
+    p { margin: 0.8em 0; }
+  </style>
+</head>
+<body>
+${content}
+</body>
+</html>`;
+  }
+
+  private async generateContentManifest(zip: JSZip): Promise<string> {
+    const files = [] as Array<{
+      path: string;
+      mime: string;
+      sha256: string;
+      role: string;
+    }>;
+
+    const entries = Object.values(zip.files);
+    for (const entry of entries) {
+      if (entry.dir || entry.name === 'content_manifest.json') {
+        continue;
+      }
+      const buffer = await entry.async('arraybuffer');
+      const sha256 = await WdocLoaderService.computeSha256(new Uint8Array(buffer));
+      files.push({
+        path: entry.name,
+        mime: this.guessMimeType(entry.name),
+        sha256,
+        role: this.determineRole(entry.name),
+      });
+    }
+
+    files.sort((a, b) => a.path.localeCompare(b.path));
+
+    const manifest = {
+      version: '1.0',
+      created: new Date().toISOString(),
+      algorithm: 'sha256',
+      files,
+    };
+
+    return JSON.stringify(manifest, null, 2);
+  }
+
+  private determineRole(path: string): string {
+    if (path === 'index.html') {
+      return 'doc_core';
+    }
+    if (path.startsWith('wdoc-form/')) {
+      return 'form_instance';
+    }
+    return 'asset';
+  }
+
+  private guessMimeType(name: string): string {
+    const ext = name.split('.').pop()?.toLowerCase();
+    switch (ext) {
+      case 'html':
+        return 'text/html';
+      case 'css':
+        return 'text/css';
+      case 'json':
+        return 'application/json';
+      case 'png':
+        return 'image/png';
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'gif':
+        return 'image/gif';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+}

--- a/src/app/services/html-processing.service.spec.ts
+++ b/src/app/services/html-processing.service.spec.ts
@@ -262,6 +262,23 @@ describe('HtmlProcessingService', () => {
     expect(httpSpy.calls.mostRecent().args[0]).toBe('assets/wdoc-styles.css');
   });
 
+  it('keeps pagination styles out of the host document', async () => {
+    const service = getService();
+    const http = TestBed.inject(HttpClient);
+    const httpSpy = spyOn(http, 'get').and.returnValue(of(''));
+    const baselineMarginTop = getComputedStyle(document.body).marginTop;
+
+    const html =
+      '<html><head><style>body{margin:32px;}</style></head><body><wdoc-page></wdoc-page></body></html>';
+
+    await service.processHtml(new JSZip(), html);
+
+    expect(document.head.querySelector('[data-pagination-styles]')).toBeNull();
+    expect(getComputedStyle(document.body).marginTop).toBe(baselineMarginTop);
+    expect(httpSpy.calls.mostRecent().args[0]).toBe('assets/wdoc-styles.css');
+    service.cleanup();
+  });
+
   it('releases object URLs during cleanup', async () => {
     const service = getService();
     const http = TestBed.inject(HttpClient);

--- a/src/app/topbar/topbar.component.css
+++ b/src/app/topbar/topbar.component.css
@@ -40,6 +40,25 @@
   gap: 0.75rem;
 }
 
+.topbar-new {
+  border: 1px solid #d0d7de;
+  background: linear-gradient(135deg, #eef2ff, #e0e7ff);
+  color: #1e1b4b;
+  padding: 0.5rem 1rem;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 700;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+
+.topbar-new:hover,
+.topbar-new:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  outline: none;
+}
+
 .attachments-wrapper {
   position: relative;
 }

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -12,6 +12,11 @@
   </button>
   <div class="topbar-title" [attr.title]="title">{{ title }}</div>
   <div class="topbar-actions">
+    @if (showNewDocument) {
+      <button type="button" class="topbar-new" (click)="onCreateNewDocument()">
+        New document
+      </button>
+    }
     @if (hasDocument) {
       <div class="zoom-controls" aria-label="Zoom controls">
         <button

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -31,6 +31,15 @@ describe('TopbarComponent', () => {
     expect(component.save.emit).toHaveBeenCalled();
   });
 
+  it('emits createNewDocument when the button is clicked', () => {
+    component.showNewDocument = true;
+    fixture.detectChanges();
+    spyOn(component.createNewDocument, 'emit');
+    const btn = fixture.nativeElement.querySelector('.topbar-new');
+    btn.click();
+    expect(component.createNewDocument.emit).toHaveBeenCalled();
+  });
+
   it('renders the provided title', () => {
     component.title = 'My Document';
     fixture.detectChanges();

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -24,9 +24,11 @@ export class TopbarComponent implements OnChanges {
   @Input() hasDocument = false;
   @Input() attachments: LoadedFile[] = [];
   @Input() formAnswers: LoadedFile[] = [];
+  @Input() showNewDocument = false;
   @Output() toggleNav = new EventEmitter<void>();
   @Output() save = new EventEmitter<void>();
   @Output() zoomChange = new EventEmitter<number>();
+  @Output() createNewDocument = new EventEmitter<void>();
   zoomValue = '100';
   attachmentsMenuOpen = false;
 
@@ -51,6 +53,10 @@ export class TopbarComponent implements OnChanges {
 
   onSave() {
     this.save.emit();
+  }
+
+  onCreateNewDocument() {
+    this.createNewDocument.emit();
   }
 
   onZoomInput(event: Event) {

--- a/src/app/viewer/viewer.component.html
+++ b/src/app/viewer/viewer.component.html
@@ -1,5 +1,1 @@
-@if (htmlContent) {
-<div #contentContainer (input)="onFormInteraction()" (change)="onFormInteraction()">
-  <div [innerHTML]="htmlContent"></div>
-</div>
-}
+<div #contentContainer class="viewer-shadow-host"></div>

--- a/src/app/viewer/viewer.component.spec.ts
+++ b/src/app/viewer/viewer.component.spec.ts
@@ -30,6 +30,20 @@ describe('ViewerComponent', () => {
     expect(host.shadowRoot?.textContent).toContain('hello');
   });
 
+  it('sanitizes SafeHtml before injecting into the shadow root', () => {
+    const safe = sanitizer.bypassSecurityTrustHtml('<div>trusted</div>');
+    component.htmlContent = safe;
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement.querySelector(
+      '.viewer-shadow-host'
+    ) as HTMLElement;
+    const shadowText = host.shadowRoot?.textContent ?? '';
+
+    expect(shadowText).toContain('trusted');
+    expect(shadowText).not.toContain('SafeValue must use [property]=binding:');
+  });
+
   it('applies zoom to the content container', async () => {
     const content: SafeHtml = sanitizer.bypassSecurityTrustHtml(
       '<wdoc-container><wdoc-page>zoom</wdoc-page></wdoc-container>'

--- a/src/app/viewer/viewer.component.ts
+++ b/src/app/viewer/viewer.component.ts
@@ -11,7 +11,8 @@ import {
   EventEmitter,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SafeHtml } from '@angular/platform-browser';
+import { SecurityContext } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-viewer',
@@ -31,6 +32,8 @@ export class ViewerComponent implements AfterViewInit, OnChanges {
   private pendingZoomRefresh = false;
   private pendingContentRender = false;
   private shadowRoot?: ShadowRoot;
+
+  constructor(private sanitizer: DomSanitizer) {}
 
   ngAfterViewInit() {
     this.createShadowRoot();
@@ -106,7 +109,9 @@ export class ViewerComponent implements AfterViewInit, OnChanges {
       this.pendingContentRender = false;
     }
 
-    const htmlString = (this.htmlContent ?? '') as unknown as string;
-    this.shadowRoot.innerHTML = htmlString;
+    const htmlString = this.htmlContent
+      ? this.sanitizer.sanitize(SecurityContext.HTML, this.htmlContent)
+      : '';
+    this.shadowRoot.innerHTML = htmlString ?? '';
   }
 }


### PR DESCRIPTION
## Summary
- add a tiptap-powered document editor surface with basic formatting controls
- introduce a service to package edited HTML into downloadable .wdoc archives and wire it to the top bar
- expose a New document action in the top bar and integrate editing mode into the main layout

## Testing
- npm test -- --watch=false --progress=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6928c0e1a73c832b87ff03377dec94e7)