### PR TITLE
Split save controls and improve form population

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,10 +22,10 @@ module.exports = function (config) {
       reporters: [{ type: "html" }, { type: "text-summary" }],
       check: {
         global: {
-          statements: 66,
-          branches: 61,
-          functions: 81,
-          lines: 81,
+          statements: 80,
+          branches: 60,
+          functions: 80,
+          lines: 80,
         },
       },
     },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,10 +22,10 @@ module.exports = function (config) {
       reporters: [{ type: "html" }, { type: "text-summary" }],
       check: {
         global: {
-          statements: 65,
-          branches: 60,
-          functions: 80,
-          lines: 80,
+          statements: 66,
+          branches: 61,
+          functions: 81,
+          lines: 81,
         },
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,13 +271,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2003.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.11.tgz",
-      "integrity": "sha512-/56v/Le9UruIPqQXINoggns0//W2/BIaDd54kvjNK5PjQUyKKj6nmhMA1RgB0yDTBFh7lksLf8IyyGx9ZchGRA==",
+      "version": "0.2003.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.12.tgz",
+      "integrity": "sha512-5H40lAFF4CKY32C4HOp6bTlOF1f4WsGCwe7FjFQp9A+T7yoCBiHpIWt2JKTwV4sBoTKVDZOnuf0GG+UVKjQT4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.11",
+        "@angular-devkit/core": "20.3.12",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -287,17 +287,17 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "20.3.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.3.11.tgz",
-      "integrity": "sha512-DCbyw/nnYxjZZHlHDnkShEeLTG7FxNppg3dMq3g+ClonTcjX4X+1TLD78UokM9idTsZikk+1A6WnOxZLDxFt2Q==",
+      "version": "20.3.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.3.12.tgz",
+      "integrity": "sha512-HPepPbJA5vprYTWJaSCfpk0s1bPT6Ui6VjFOSb9oY+p9iq+MGkuB1I+swNcRcMLttyMD+FpbMd27F8jSeX5XVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.11",
-        "@angular-devkit/build-webpack": "0.2003.11",
-        "@angular-devkit/core": "20.3.11",
-        "@angular/build": "20.3.11",
+        "@angular-devkit/architect": "0.2003.12",
+        "@angular-devkit/build-webpack": "0.2003.12",
+        "@angular-devkit/core": "20.3.12",
+        "@angular/build": "20.3.12",
         "@babel/core": "7.28.3",
         "@babel/generator": "7.28.3",
         "@babel/helper-annotate-as-pure": "7.27.3",
@@ -308,7 +308,7 @@
         "@babel/preset-env": "7.28.3",
         "@babel/runtime": "7.28.3",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "20.3.11",
+        "@ngtools/webpack": "20.3.12",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.21",
         "babel-loader": "10.0.0",
@@ -363,7 +363,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/platform-server": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.11",
+        "@angular/ssr": "^20.3.12",
         "@web/test-runner": "^0.20.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0 || ^30.2.0",
@@ -420,13 +420,13 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.2003.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2003.11.tgz",
-      "integrity": "sha512-FShY/esFad74pstEFCkin1MgEziXd33fy5Fs0hfMVKxWWKRbtPMSQd8qNd9s+olIYRX/rSOeCuuYXesOtUnodg==",
+      "version": "0.2003.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2003.12.tgz",
+      "integrity": "sha512-IkhCU0nAsXYBQOfHu2gQBcYBKhaV1c8wYtu7MmelBcN/iUrG8hRf1sZx+ppUgsdZuBYxCiDiLpcfRVRCIASkvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2003.11",
+        "@angular-devkit/architect": "0.2003.12",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "20.3.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.11.tgz",
-      "integrity": "sha512-KZDhMemUci42D9CNziM+GxQK5wEMP+TDL9ssUHIkvrr1lsFViHIO+pfzs7QfyM8n6hr7at4gQN9IZRV4rRKyQQ==",
+      "version": "20.3.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.12.tgz",
+      "integrity": "sha512-ReFxd/UOoVDr3+kIUjmYILQZF89qg62POdY7a7OqBH7plmInFlYVSEDouJvGqj3LVCPiqTk2ZOSChbhS/eLxXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -468,13 +468,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "20.3.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.11.tgz",
-      "integrity": "sha512-ePbARvd3xaN2a+ozFWaoYQHz1pzyzzu247rxRoS4hSOr5jqCsogMqPoGxdBCx6nFlDlP/CYenFR7cFx5OBT4tg==",
+      "version": "20.3.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.12.tgz",
+      "integrity": "sha512-JqJ1u59y+Ud51k/8MHYzSP+aQOeC2PJBaDmMnvqfWVaIt6n3x4gc/VtuhqhpJ0SKulbFuOWgAfI6QbPFrgUYQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.11",
+        "@angular-devkit/core": "20.3.12",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "8.2.0",
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.13.tgz",
-      "integrity": "sha512-IOiZlb+GK3p70J4vRe3PQ+NHCkoVYaq7fz9Pg2FcQ9Ar3EobVtHyFJFGzdStMFbiYR0B66STBNyZcz+V0AwC0A==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.14.tgz",
+      "integrity": "sha512-Sx3/XNu2rR+R8T8JkJEaIpZDZPk0IecS0Ayt6HTanNUZXuw0HVou3vkjR5B2St5nM4MXs0gh+S6aLNuArtqJTQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -498,18 +498,18 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.3.13"
+        "@angular/core": "20.3.14"
       }
     },
     "node_modules/@angular/build": {
-      "version": "20.3.11",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.11.tgz",
-      "integrity": "sha512-0YJGRSXZeH3ncpyCZANN0jDdWaRhIOzKQ54+YcuA1uwLzTAUrla3CsJHSVk6ljItIRWymPuUMDRHjxWE/W6WbA==",
+      "version": "20.3.12",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.12.tgz",
+      "integrity": "sha512-iAZve4VPviC8y6RFctyh3qFXSlP5mth9K46/0zasB4LV4pcmu8BrzIHERxIn/jCDNdVdPh973kxo1ksO4WpyuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.11",
+        "@angular-devkit/architect": "0.2003.12",
         "@babel/core": "7.28.3",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -551,7 +551,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/platform-server": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.11",
+        "@angular/ssr": "^20.3.12",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^20.0.0",
@@ -617,19 +617,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "20.3.11",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.11.tgz",
-      "integrity": "sha512-FmTvBWo32MAhY2rdXbPjCfC71o0tIzYBuzrjE42SU0+brwwWSvWUmRxS6xM+hH87QrF+gzmi26hOql891OfbIg==",
+      "version": "20.3.12",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.12.tgz",
+      "integrity": "sha512-vqVyVjbFPCRMjA5evL7tV2JeR6Anuzb9WcXTMB17fr7uzKNNAvo7KyRaOJjp+TU4JDARTNyGPy0aywfPx7R60A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2003.11",
-        "@angular-devkit/core": "20.3.11",
-        "@angular-devkit/schematics": "20.3.11",
+        "@angular-devkit/architect": "0.2003.12",
+        "@angular-devkit/core": "20.3.12",
+        "@angular-devkit/schematics": "20.3.12",
         "@inquirer/prompts": "7.8.2",
         "@listr2/prompt-adapter-inquirer": "3.0.1",
         "@modelcontextprotocol/sdk": "1.17.3",
-        "@schematics/angular": "20.3.11",
+        "@schematics/angular": "20.3.12",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.35.0",
         "ini": "5.0.0",
@@ -652,9 +652,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.13.tgz",
-      "integrity": "sha512-Jy+Qu6760TZyiDJX0+fNzkc70+lwF9ojdkIyCso/Lvbx1v3Fki0+9Wui7Vge56hknkr05xXg1aEUeqMN0966Lg==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.14.tgz",
+      "integrity": "sha512-OOUvjTtnpktJLsNupA+GFT2q5zNocPdpOENA8aSrXvAheNybLjgi+otO3U3sQsvB1VwaoEZ9GT5O3lZlstnA/A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -663,14 +663,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.3.13",
+        "@angular/core": "20.3.14",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.13.tgz",
-      "integrity": "sha512-YEjzHxz9laEcC2YPBA7L09Ys8UIuPrRiBZcGCrOXzXmPATHGYuxqYuhZ8iKmKV0PG/4pP2fxD3Mv5wN0cBaOWg==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.14.tgz",
+      "integrity": "sha512-KFbfPPAbclzGDujCVruflCD9j4Zwwxvrg7Y4C9GJYs3LZ85t+BfIMDDnvpBUM07ZLnfY4TO4gQdHmJAcaGGXDQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -680,9 +680,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.13.tgz",
-      "integrity": "sha512-Cou3G8C60eKpD93SKBJRG5pa/xpmMHe6sc2aanWjneGWjZq1kR4v5eQwwr8LUByIsafcqxHGT7+q1bYXT2p2DQ==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.14.tgz",
+      "integrity": "sha512-lFg9ikwRClzDPjdFiwynbVFIi1RJZf/0i+OHa3Ns2gzXxJeHNKMJrHHjWZ2DU4N2UpxH0YAPe22N9Bie28IuQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -703,7 +703,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.13",
+        "@angular/compiler": "20.3.14",
         "typescript": ">=5.8 <6.0"
       },
       "peerDependenciesMeta": {
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.13.tgz",
-      "integrity": "sha512-12Kou+WAIjAUSG5TkDbypV2kreJ105VylAjlQ09bCvsGNTHjezGgahFa/tLz7iyrozhuivtGiQtiDaYsc79ysw==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.14.tgz",
+      "integrity": "sha512-rpyEbhWF6Fj/xI9IvNLZh5QBUYnoXuF7vX54CCtyQ2MHALxRR/aa1WRxjRM96cF2OqodQ/Gj3oYW8ei8hlBh4w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -724,7 +724,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.13",
+        "@angular/compiler": "20.3.14",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
       },
@@ -738,9 +738,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.13.tgz",
-      "integrity": "sha512-9vu9MCHJtgXvgPH+ZgXN46N3gpBBAckcmG62P7U+9BKivWvv3rEvkgX+4HvO+Pm2D6x/Jy1xbiQuVq9EDGPSNA==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.14.tgz",
+      "integrity": "sha512-fGrJ589tU+AKoxf+kaRrEw7wlSfVr1/z/Fz625ggFCc6ySQEityKW3JsnLfNkh5qGrdxib4BOfF78f9J7Pyk+w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -749,9 +749,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.13",
-        "@angular/core": "20.3.13",
-        "@angular/platform-browser": "20.3.13",
+        "@angular/common": "20.3.14",
+        "@angular/core": "20.3.14",
+        "@angular/platform-browser": "20.3.14",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -773,9 +773,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.13.tgz",
-      "integrity": "sha512-KyJzzpD4jMPGotDgVHF0cz9psjlVg6wYQrhuWcLeE97VUvp+CdwdOJ9tlxDlGE5tYZ0JrQxAT0l5qdcr6K9iNQ==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.14.tgz",
+      "integrity": "sha512-Lviz9GfsIyOIBDal8QhIBKU8OMH29A0RhFw2opTC50sqKadXLN9CD7iSaAwQbNLc4mc3JAF4zth0AzKdHLbz7Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -784,9 +784,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "20.3.13",
-        "@angular/common": "20.3.13",
-        "@angular/core": "20.3.13"
+        "@angular/animations": "20.3.14",
+        "@angular/common": "20.3.14",
+        "@angular/core": "20.3.14"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -795,9 +795,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.13.tgz",
-      "integrity": "sha512-/kBhzn/TewEPuoUeTh3+uJmviBoaey9g2qegwKj0rrr5XGqoEWurOY6yl8DqZCVHVimLZJdx8bBN7TEi7KlsLg==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.14.tgz",
+      "integrity": "sha512-g9z/g8gIOrBCX1SQ/GWwB0+JXBC6CKe0+yRyy9GGeBLm/YXWZHxTkmnDmueXXfPtUl8TOAInE22wlLcfunWTrg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -806,16 +806,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.13",
-        "@angular/compiler": "20.3.13",
-        "@angular/core": "20.3.13",
-        "@angular/platform-browser": "20.3.13"
+        "@angular/common": "20.3.14",
+        "@angular/compiler": "20.3.14",
+        "@angular/core": "20.3.14",
+        "@angular/platform-browser": "20.3.14"
       }
     },
     "node_modules/@angular/router": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.13.tgz",
-      "integrity": "sha512-TpNnqmcCFsAnf3tzdtWeGSSmHb9VTKCI6/1NRBgvpiiNSZ4ehQ/rPTy7D4q5uhu50vB0VECUSGkUAygQI8YHdw==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.14.tgz",
+      "integrity": "sha512-gi7/NuHRS9n9RCwh03VuVFizVMa2lKL/s+7yP3Ecq2nQ5uSeTMWb/91OmGEBwncI3wKPkYdQ9g3n6PvK/O8uDQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -824,16 +824,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.13",
-        "@angular/core": "20.3.13",
-        "@angular/platform-browser": "20.3.13",
+        "@angular/common": "20.3.14",
+        "@angular/core": "20.3.14",
+        "@angular/platform-browser": "20.3.14",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/service-worker": {
-      "version": "20.3.13",
-      "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-20.3.13.tgz",
-      "integrity": "sha512-WsWIbbSJXTYopKyQ98LHVAEu/gJaTIKZukfrnC4aRFfNnz72NQHDTFNfPQt3DQ7LXGIrN5TZkbbgeMKT3mfT+g==",
+      "version": "20.3.14",
+      "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-20.3.14.tgz",
+      "integrity": "sha512-deqrAszJ534/wUTjb7UByoX0SgOJAWPE6g+y1HZv6Uy9OJYakkbwBt4lKqftHkga9guBsHkZydDfJNBIrSAbkw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -845,7 +845,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.3.13",
+        "@angular/core": "20.3.14",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -4156,9 +4156,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "20.3.11",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.3.11.tgz",
-      "integrity": "sha512-c2/66tObP9YevCt7jyhwiGifS8ldfce6vYQ63Wwj8tlXSSutHk8+3VEQmbW3wW1JH7+0aNf3kF+pA97EbGj6QA==",
+      "version": "20.3.12",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-20.3.12.tgz",
+      "integrity": "sha512-ePuofHOtbgvEq2t+hcmL30s4q9HQ/nv9ABwpLiELdVIObcWUnrnizAvM7hujve/9CQL6gRCeEkxPLPS4ZrK9AQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4850,13 +4850,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.56.1"
+        "playwright": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5336,14 +5336,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "20.3.11",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.11.tgz",
-      "integrity": "sha512-9mU8nEsty96LT1t+lShDdcfEhJDVfc2sNHEIQsFY8gUVXspkT7lj570odHLqC5aumDYtWc3B/kRSzPxh8SPWFg==",
+      "version": "20.3.12",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.12.tgz",
+      "integrity": "sha512-ikl+nkWUab/Z4eSkBHgq9FLIUH8qh4OcYKeBQ0fyWqIUFHyjjK0JOfwmH1g/3zAmuUMtkthHCehAtyKzCTQjVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.11",
-        "@angular-devkit/schematics": "20.3.11",
+        "@angular-devkit/core": "20.3.12",
+        "@angular-devkit/schematics": "20.3.12",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -6872,9 +6872,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz",
-      "integrity": "sha512-zGUCsm3yv/ePt2PHNbVxjjn0nNB1MkIaR4wOCxJ2ig5pCf5cCVAYJXVhQg/3OhhJV6DB1ts7Hv0oUaElc2TPQg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -6959,9 +6959,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.30",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.30.tgz",
-      "integrity": "sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==",
+      "version": "2.8.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.31.tgz",
+      "integrity": "sha512-a28v2eWrrRWPpJSzxc+mKwm0ZtVx/G8SepdQZDArnXYU/XS+IF6mp8aB/4E+hH1tyGCoDo3KlUCdlSxGDsRkAw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7028,37 +7028,28 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
         "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bonjour-service": {
@@ -7344,9 +7335,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001756",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001756.tgz",
-      "integrity": "sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==",
+      "version": "1.0.30001757",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
+      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
       "dev": true,
       "funding": [
         {
@@ -8303,9 +8294,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.259",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.259.tgz",
-      "integrity": "sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==",
+      "version": "1.5.262",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
+      "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -11935,9 +11926,9 @@
       "optional": true
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
@@ -12158,9 +12149,9 @@
       }
     },
     "node_modules/npm-packlist/node_modules/proc-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.0.0.tgz",
-      "integrity": "sha512-KG/XsTDN901PNfPfAMmj6N/Ywg9tM+bHK8pAz+27fS4N4Pcr+4zoYBOcGSBu6ceXYNPxkLpa4ohtfxV1XcLAfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -12860,9 +12851,9 @@
       }
     },
     "node_modules/pkce-challenge": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12870,13 +12861,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.1"
+        "playwright-core": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12889,9 +12880,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13042,9 +13033,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13656,46 +13647,19 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/readable-stream": {

--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -7,7 +7,7 @@
   >
     <app-navbar
       (fileSelected)="onFileSelected($event)"
-      [showSave]="showSave"
+      [showSave]="showFormSave || showDocumentSave"
       (save)="onSaveForms()"
       (closeNav)="closeNav()"
     ></app-navbar>
@@ -15,8 +15,9 @@
 
   <mat-sidenav-content>
     <div class="main-content">
-      <app-topbar
-        [showSave]="isEditing || showSave"
+    <app-topbar
+        [showFormSave]="!isEditing && showFormSave"
+        [showDocumentSave]="isEditing && showDocumentSave"
         [navOpen]="isNavOpen"
         [title]="documentTitle"
         [zoom]="zoom"
@@ -25,7 +26,8 @@
         [formAnswers]="formAnswers"
         [showNewDocument]="true"
         (toggleNav)="toggleNav()"
-        (save)="isEditing ? onSaveNewDocument() : onSaveForms()"
+        (saveForm)="onSaveForms()"
+        (saveDocument)="onSaveNewDocument()"
         (zoomChange)="onZoomChange($event)"
         (createNewDocument)="startNewDocument()"
       ></app-topbar>

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -44,11 +44,11 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should mark showSave when form input changes', () => {
+  it('should mark showFormSave when form input changes', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance as any;
     app.onFormInteraction();
-    expect(app.showSave).toBeTrue();
+    expect(app.showFormSave).toBeTrue();
   });
 
   it('clamps zoom changes within bounds', () => {
@@ -148,19 +148,19 @@ describe('AppComponent', () => {
     ).toBeTrue();
   });
 
-  it('calls saveForms when saving and resets showSave', async () => {
+  it('calls saveForms when saving and resets showFormSave', async () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     const buffer = new ArrayBuffer(8);
     (app as any).originalArrayBuffer = buffer;
     const container = document.createElement('div');
     (app as any).viewer = { nativeElement: container } as any;
-    formManager.saveForms.and.resolveTo();
+    formManager.saveForms.and.resolveTo(true);
 
     await app.onSaveForms();
 
     expect(formManager.saveForms).toHaveBeenCalledWith(container, buffer);
-    expect(app.showSave).toBeFalse();
+    expect(app.showFormSave).toBeFalse();
   });
 
   it('creates a new document and triggers a download on save', async () => {

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -98,10 +98,18 @@
     <button
       class="topbar-save"
       type="button"
-      (click)="onSave()"
-      [hidden]="!showSave"
+      (click)="onSaveForm()"
+      [hidden]="!showFormSave"
     >
-      Save
+      Save form
+    </button>
+    <button
+      class="topbar-save"
+      type="button"
+      (click)="onSaveDocument()"
+      [hidden]="!showDocumentSave"
+    >
+      Save document
     </button>
   </div>
 </header>

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -22,13 +22,27 @@ describe('TopbarComponent', () => {
     expect(component.toggleNav.emit).toHaveBeenCalled();
   });
 
-  it('emits save when save button clicked', () => {
-    component.showSave = true;
+  it('emits save form when save form button clicked', () => {
+    component.showFormSave = true;
     fixture.detectChanges();
-    spyOn(component.save, 'emit');
+    spyOn(component.saveForm, 'emit');
     const btn = fixture.nativeElement.querySelector('.topbar-save');
     btn.click();
-    expect(component.save.emit).toHaveBeenCalled();
+    expect(component.saveForm.emit).toHaveBeenCalled();
+  });
+
+  it('emits save document when save document button clicked', () => {
+    component.showDocumentSave = true;
+    fixture.detectChanges();
+    spyOn(component.saveDocument, 'emit');
+    const buttons = fixture.nativeElement.querySelectorAll(
+      '.topbar-save',
+    ) as NodeListOf<HTMLButtonElement>;
+    const docButton = Array.from(buttons).find((btn) =>
+      btn.textContent?.includes('document'),
+    );
+    docButton?.click();
+    expect(component.saveDocument.emit).toHaveBeenCalled();
   });
 
   it('emits createNewDocument when the button is clicked', () => {

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -17,7 +17,8 @@ import { LoadedFile } from '../services/wdoc-loader.service';
   styleUrls: ['./topbar.component.css'],
 })
 export class TopbarComponent implements OnChanges {
-  @Input() showSave = false;
+  @Input() showFormSave = false;
+  @Input() showDocumentSave = false;
   @Input() navOpen = false;
   @Input() title = 'WDOC viewer';
   @Input() zoom = 100;
@@ -26,7 +27,8 @@ export class TopbarComponent implements OnChanges {
   @Input() formAnswers: LoadedFile[] = [];
   @Input() showNewDocument = false;
   @Output() toggleNav = new EventEmitter<void>();
-  @Output() save = new EventEmitter<void>();
+  @Output() saveForm = new EventEmitter<void>();
+  @Output() saveDocument = new EventEmitter<void>();
   @Output() zoomChange = new EventEmitter<number>();
   @Output() createNewDocument = new EventEmitter<void>();
   zoomValue = '100';
@@ -51,8 +53,12 @@ export class TopbarComponent implements OnChanges {
     this.toggleNav.emit();
   }
 
-  onSave() {
-    this.save.emit();
+  onSaveForm() {
+    this.saveForm.emit();
+  }
+
+  onSaveDocument() {
+    this.saveDocument.emit();
   }
 
   onCreateNewDocument() {


### PR DESCRIPTION
## Summary
- add distinct Save form and Save document controls with matching app state handling
- ensure form population persists text values and attachments from existing wdoc-form entries, including login.json cases
- raise coverage thresholds by 1% and extend specs for the updated save flow

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless --progress=false *(fails: missing @tiptap/* editor dependencies in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692952580f40832b8e0d73ce7afbb4c5)