### PR TITLE
Refine editor pagination and deployment config

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm ci
 
       - name: Build Angular wdocviewer
+        env:
+          SUPABASE_REDIRECT_URL: https://app.wdoc.info
         run: |
           npm run build -- --configuration=production --base-href="/"
 

--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -10,6 +10,7 @@
       [showSave]="showFormSave || showDocumentSave"
       (save)="onSaveForms()"
       (closeNav)="closeNav()"
+      (createNewDocument)="startNewDocument()"
     ></app-navbar>
   </mat-sidenav>
 
@@ -24,12 +25,10 @@
         [hasDocument]="!isEditing && !!htmlContent"
         [attachments]="attachments"
         [formAnswers]="formAnswers"
-        [showNewDocument]="true"
         (toggleNav)="toggleNav()"
         (saveForm)="onSaveForms()"
         (saveDocument)="onSaveNewDocument()"
         (zoomChange)="onZoomChange($event)"
-        (createNewDocument)="startNewDocument()"
       ></app-topbar>
       @if (isEditing) {
         <app-document-editor

--- a/src/app/editor/document-editor.component.css
+++ b/src/app/editor/document-editor.component.css
@@ -51,34 +51,18 @@
 .page-list {
   position: relative;
   margin: 0 auto;
-}
-
-.page-stack {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  pointer-events: none;
-}
-
-.page-stack wdoc-page {
-  margin: 0 0 20px 0;
-  background: #fff;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
-  border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  width: 100%;
-  height: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .page-shell {
   position: relative;
-  z-index: 1;
   background: #fff;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
   border-radius: 8px;
   border: 1px solid rgba(0, 0, 0, 0.06);
   box-sizing: border-box;
-  margin-bottom: 20px;
 }
 
 .editor-surface {
@@ -95,6 +79,12 @@
 }
 
 .ProseMirror,
-.ProseMirror-focused {
-  outline: none;
+.ProseMirror-focused,
+.editor-wrapper .tiptap.ProseMirror:focus-visible {
+  outline: none !important;
+  box-shadow: none;
+}
+
+.editor-surface:focus-visible {
+  outline: none !important;
 }

--- a/src/app/editor/document-editor.component.css
+++ b/src/app/editor/document-editor.component.css
@@ -35,17 +35,47 @@
   border-color: #312e81;
 }
 
-.editor-surface {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 18px 20px;
-  min-height: 420px;
-  line-height: 1.6;
-  font-size: 16px;
+.editor-container {
+  background: transparent;
+  padding: 12px 0 0;
+  height: auto;
+  min-height: calc(100vh - 200px);
 }
 
-.editor-surface:focus-within {
-  outline: 2px solid #4338ca;
-  outline-offset: 3px;
+.editor-content {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.page-list {
+  position: relative;
+  margin: 0 auto;
+}
+
+.page-stack {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  pointer-events: none;
+}
+
+.page-stack wdoc-page {
+  margin: 0 0 20px 0;
+}
+
+.editor-surface {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+  border: none;
+  line-height: 1.6;
+  font-size: 16px;
+  box-sizing: border-box;
+  margin: 0 auto;
+}
+
+.ProseMirror,
+.ProseMirror-focused {
+  outline: none;
 }

--- a/src/app/editor/document-editor.component.css
+++ b/src/app/editor/document-editor.component.css
@@ -62,17 +62,36 @@
 
 .page-stack wdoc-page {
   margin: 0 0 20px 0;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  width: 100%;
+  height: auto;
+}
+
+.page-shell {
+  position: relative;
+  z-index: 1;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  box-sizing: border-box;
+  margin-bottom: 20px;
 }
 
 .editor-surface {
-  position: relative;
-  z-index: 1;
-  background: transparent;
+  width: 100%;
   border: none;
   line-height: 1.6;
   font-size: 16px;
   box-sizing: border-box;
-  margin: 0 auto;
+  margin: 0;
+}
+
+.editor-wrapper :focus-visible {
+  outline: none;
 }
 
 .ProseMirror,

--- a/src/app/editor/document-editor.component.css
+++ b/src/app/editor/document-editor.component.css
@@ -9,6 +9,12 @@
   min-height: calc(100vh - 96px);
 }
 
+:host {
+  --page-width: 793.8px;
+  --page-height: 1122px;
+  --page-padding: 20px;
+}
+
 .editor-toolbar {
   display: flex;
   flex-wrap: wrap;
@@ -54,6 +60,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  width: var(--page-width);
 }
 
 .page-shell {
@@ -63,6 +70,9 @@
   border-radius: 8px;
   border: 1px solid rgba(0, 0, 0, 0.06);
   box-sizing: border-box;
+  width: var(--page-width);
+  min-height: var(--page-height);
+  padding: var(--page-padding);
 }
 
 .editor-surface {
@@ -72,6 +82,7 @@
   font-size: 16px;
   box-sizing: border-box;
   margin: 0;
+  min-height: calc(var(--page-height) - var(--page-padding) * 2);
 }
 
 .editor-wrapper :focus-visible {

--- a/src/app/editor/document-editor.component.html
+++ b/src/app/editor/document-editor.component.html
@@ -19,5 +19,29 @@
       Numbered list
     </button>
   </div>
-  <div #editorHost class="editor-surface" aria-label="Document content"></div>
+
+  <wdoc-container class="editor-container">
+    <wdoc-content class="editor-content">
+      <div
+        class="page-list"
+        [style.width.px]="pageWidth"
+        [style.minHeight.px]="pageStackHeight"
+      >
+        <div class="page-stack" [style.height.px]="pageStackHeight" aria-hidden="true">
+          @for (page of pageCountArray; track page) {
+            <wdoc-page></wdoc-page>
+          }
+        </div>
+
+        <div
+          #editorHost
+          class="editor-surface"
+          aria-label="Document content"
+          [style.width.px]="pageWidth"
+          [style.minHeight.px]="pageHeight"
+          [style.padding.px]="pagePadding"
+        ></div>
+      </div>
+    </wdoc-content>
+  </wdoc-container>
 </div>

--- a/src/app/editor/document-editor.component.html
+++ b/src/app/editor/document-editor.component.html
@@ -22,34 +22,23 @@
 
   <wdoc-container class="editor-container">
     <wdoc-content class="editor-content">
-      <div
-        class="page-list"
-        [style.width.px]="pageWidth"
-        [style.minHeight.px]="pageStackHeight"
-      >
-        <div class="page-stack" [style.height.px]="pageStackHeight" aria-hidden="true">
-          @for (page of pageCountArray; track page) {
-            <wdoc-page
-              [style.width.px]="pageWidth"
-              [style.height.px]="pageHeight"
-              [style.padding.px]="pagePadding"
-            ></wdoc-page>
-          }
-        </div>
-
-        <wdoc-page
-          class="page-shell"
-          [style.width.px]="pageWidth"
-          [style.minHeight.px]="pageHeight"
-          [style.padding.px]="pagePadding"
-        >
-          <div
-            #editorHost
-            class="editor-surface"
-            aria-label="Document content"
-            [style.minHeight.px]="pageHeight - pagePadding * 2"
-          ></div>
-        </wdoc-page>
+      <div class="page-list" [style.width.px]="pageWidth">
+        @for (page of pageContents; let i = $index; track i) {
+          <wdoc-page
+            class="page-shell"
+            [style.width.px]="pageWidth"
+            [style.minHeight.px]="pageHeight"
+            [style.padding.px]="pagePadding"
+          >
+            <div
+              #pageHost
+              class="editor-surface"
+              aria-label="Document content"
+              [attr.data-page-index]="i"
+              [style.minHeight.px]="pageHeight - pagePadding * 2"
+            ></div>
+          </wdoc-page>
+        }
       </div>
     </wdoc-content>
   </wdoc-container>

--- a/src/app/editor/document-editor.component.html
+++ b/src/app/editor/document-editor.component.html
@@ -22,20 +22,16 @@
 
   <wdoc-container class="editor-container">
     <wdoc-content class="editor-content">
-      <div class="page-list" [style.width.px]="pageWidth">
+      <div class="page-list">
         @for (page of pageContents; let i = $index; track i) {
           <wdoc-page
             class="page-shell"
-            [style.width.px]="pageWidth"
-            [style.minHeight.px]="pageHeight"
-            [style.padding.px]="pagePadding"
           >
             <div
               #pageHost
               class="editor-surface"
               aria-label="Document content"
               [attr.data-page-index]="i"
-              [style.minHeight.px]="pageHeight - pagePadding * 2"
             ></div>
           </wdoc-page>
         }

--- a/src/app/editor/document-editor.component.html
+++ b/src/app/editor/document-editor.component.html
@@ -29,18 +29,27 @@
       >
         <div class="page-stack" [style.height.px]="pageStackHeight" aria-hidden="true">
           @for (page of pageCountArray; track page) {
-            <wdoc-page></wdoc-page>
+            <wdoc-page
+              [style.width.px]="pageWidth"
+              [style.height.px]="pageHeight"
+              [style.padding.px]="pagePadding"
+            ></wdoc-page>
           }
         </div>
 
-        <div
-          #editorHost
-          class="editor-surface"
-          aria-label="Document content"
+        <wdoc-page
+          class="page-shell"
           [style.width.px]="pageWidth"
           [style.minHeight.px]="pageHeight"
           [style.padding.px]="pagePadding"
-        ></div>
+        >
+          <div
+            #editorHost
+            class="editor-surface"
+            aria-label="Document content"
+            [style.minHeight.px]="pageHeight - pagePadding * 2"
+          ></div>
+        </wdoc-page>
       </div>
     </wdoc-content>
   </wdoc-container>

--- a/src/app/editor/document-editor.component.spec.ts
+++ b/src/app/editor/document-editor.component.spec.ts
@@ -5,6 +5,14 @@ import { DocumentEditorComponent } from './document-editor.component';
 describe('DocumentEditorComponent', () => {
   let fixture: ComponentFixture<DocumentEditorComponent>;
   let component: DocumentEditorComponent;
+  const flushRaf = () =>
+    new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  const settle = async () => {
+    await fixture.whenStable();
+    await flushRaf();
+    fixture.detectChanges();
+    await flushRaf();
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,30 +22,54 @@ describe('DocumentEditorComponent', () => {
     fixture = TestBed.createComponent(DocumentEditorComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    await settle();
   });
 
-  it('emits content changes when the document updates', () => {
+  it('emits content changes when the document updates', async () => {
     const emitSpy = spyOn(component.contentChange, 'emit');
     component.editor?.commands.setContent('<p>Updated</p>');
+    await flushRaf();
     expect(emitSpy).toHaveBeenCalled();
   });
 
-  it('updates the live document when the input content changes', () => {
+  it('updates the live document when the input content changes', async () => {
     component.content = '<p>Reset</p>';
     component.ngOnChanges({
       content: new SimpleChange(undefined, component.content, false),
     });
 
+    await settle();
+
     expect(component.editor?.getHTML()).toContain('Reset');
   });
 
-  it('exposes basic formatting commands', () => {
+  it('exposes basic formatting commands', async () => {
     component.toggleBold();
     component.toggleItalic();
     component.toggleBulletList();
     component.toggleOrderedList();
     component.setHeading(2);
 
+    await settle();
     expect(component.editor?.isActive('heading', { level: 2 })).toBeTrue();
+  });
+
+  it('clears the placeholder when the editor gains focus', async () => {
+    const editor = component.editor!;
+    editor.options.onFocus?.({ editor } as any);
+
+    await settle();
+    expect(editor.getHTML()).toBe('<p></p>');
+  });
+
+  it('paginates content when the available height is exceeded', async () => {
+    component.pageHeight = 120;
+    component.content = `<p>${'line<br>'.repeat(200)}</p>`;
+    component.ngOnChanges({
+      content: new SimpleChange(undefined, component.content, false),
+    });
+
+    await settle();
+    expect(component.pageContents.length).toBeGreaterThan(1);
   });
 });

--- a/src/app/editor/document-editor.component.ts
+++ b/src/app/editor/document-editor.component.ts
@@ -6,6 +6,7 @@ import {
   EventEmitter,
   Input,
   OnDestroy,
+  OnInit,
   OnChanges,
   SimpleChanges,
   Output,
@@ -26,7 +27,7 @@ import { Level } from '@tiptap/extension-heading';
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class DocumentEditorComponent
-  implements AfterViewInit, OnDestroy, OnChanges
+  implements OnInit, AfterViewInit, OnDestroy, OnChanges
 {
   @Input() content = '<p>Start writing...</p>';
   @Output() contentChange = new EventEmitter<string>();
@@ -43,6 +44,15 @@ export class DocumentEditorComponent
   private paginationRaf = 0;
   private placeholderCleared = false;
   private pendingSelectionOffset: number | null = null;
+
+  get editor(): Editor | undefined {
+    return this.editors[0];
+  }
+
+  ngOnInit(): void {
+    this.placeholderCleared = this.content !== '<p>Start writing...</p>';
+    this.updatePagesFromHtml(this.content);
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (
@@ -66,8 +76,6 @@ export class DocumentEditorComponent
   }
 
   ngAfterViewInit(): void {
-    this.placeholderCleared = this.content !== '<p>Start writing...</p>';
-    this.updatePagesFromHtml(this.content);
     this.syncEditorsToHosts();
     this.pageHosts?.changes.subscribe(() => this.syncEditorsToHosts());
   }

--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -64,6 +64,11 @@
   font-weight: 600;
 }
 
+.nav-btn.primary {
+  background-color: #e4efff;
+  color: #0f172a;
+}
+
 .auth-btn {
   width: 100%;
   display: flex;

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -13,6 +13,9 @@
     </button>
   </header>
   <div class="nav-content">
+    <button type="button" class="nav-btn primary" (click)="onCreateNewDocument()">
+      New document
+    </button>
     <button type="button" class="nav-btn" (click)="triggerFileDialog()">
       Open .wdoc or .zip file
     </button>

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -25,6 +25,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   @Output() save = new EventEmitter<void>();
   @Input() showSave = false;
   @Output() closeNav = new EventEmitter<void>();
+  @Output() createNewDocument = new EventEmitter<void>();
   @ViewChild('fileInput') fileInput?: ElementRef<HTMLInputElement>;
 
   isAuthModalOpen = false;
@@ -58,6 +59,11 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   triggerFileDialog() {
     this.fileInput?.nativeElement.click();
+  }
+
+  onCreateNewDocument(): void {
+    this.createNewDocument.emit();
+    this.closeNav.emit();
   }
 
   onCloseNav() {

--- a/src/app/topbar/topbar.component.css
+++ b/src/app/topbar/topbar.component.css
@@ -40,25 +40,6 @@
   gap: 0.75rem;
 }
 
-.topbar-new {
-  border: 1px solid #d0d7de;
-  background: linear-gradient(135deg, #eef2ff, #e0e7ff);
-  color: #1e1b4b;
-  padding: 0.5rem 1rem;
-  border-radius: 10px;
-  cursor: pointer;
-  font-weight: 700;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-  transition: transform 0.1s ease, box-shadow 0.15s ease;
-}
-
-.topbar-new:hover,
-.topbar-new:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-  outline: none;
-}
-
 .attachments-wrapper {
   position: relative;
 }

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -12,11 +12,6 @@
   </button>
   <div class="topbar-title" [attr.title]="title">{{ title }}</div>
   <div class="topbar-actions">
-    @if (showNewDocument) {
-      <button type="button" class="topbar-new" (click)="onCreateNewDocument()">
-        New document
-      </button>
-    }
     @if (hasDocument) {
       <div class="zoom-controls" aria-label="Zoom controls">
         <button

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -45,15 +45,6 @@ describe('TopbarComponent', () => {
     expect(component.saveDocument.emit).toHaveBeenCalled();
   });
 
-  it('emits createNewDocument when the button is clicked', () => {
-    component.showNewDocument = true;
-    fixture.detectChanges();
-    spyOn(component.createNewDocument, 'emit');
-    const btn = fixture.nativeElement.querySelector('.topbar-new');
-    btn.click();
-    expect(component.createNewDocument.emit).toHaveBeenCalled();
-  });
-
   it('renders the provided title', () => {
     component.title = 'My Document';
     fixture.detectChanges();

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -25,12 +25,10 @@ export class TopbarComponent implements OnChanges {
   @Input() hasDocument = false;
   @Input() attachments: LoadedFile[] = [];
   @Input() formAnswers: LoadedFile[] = [];
-  @Input() showNewDocument = false;
   @Output() toggleNav = new EventEmitter<void>();
   @Output() saveForm = new EventEmitter<void>();
   @Output() saveDocument = new EventEmitter<void>();
   @Output() zoomChange = new EventEmitter<number>();
-  @Output() createNewDocument = new EventEmitter<void>();
   zoomValue = '100';
   attachmentsMenuOpen = false;
 
@@ -59,10 +57,6 @@ export class TopbarComponent implements OnChanges {
 
   onSaveDocument() {
     this.saveDocument.emit();
-  }
-
-  onCreateNewDocument() {
-    this.createNewDocument.emit();
   }
 
   onZoomInput(event: Event) {


### PR DESCRIPTION
## Summary
- update the GitHub Pages build to expose the production Supabase magic link redirect URL
- move the New document action into the navigation panel and adjust parent wiring
- restyle the WYSIWYG editor with wdoc container/page scaffolding, remove the focus border, and extend pagination visuals when content overflows

## Testing
- npm start -- --host 0.0.0.0 --port 4200


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69296484ebf0832bb34318d49f04e995)