### PR TITLE
Move content hashes into manifest.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This project is an **Angular 20+** application serving as a viewer for **.wdoc**
 **What is a .wdoc?** It is a zipped archive containing:
 
 - `index.html` (The entry point).
-- `content_manifest.json` (Security verification).
+- `manifest.json` (Security verification and metadata).
 - Assets (Images, CSS) referenced relatively.
 - `wdoc-form/` (JSON data for form state persistence).
 
@@ -30,7 +30,7 @@ The viewer is designed as an "anti-PDF," rendering HTML/CSS natively in the brow
 
 1. **Input:** File input or Drag-and-Drop.
 2. **Loader:** `WdocLoaderService` reads the ArrayBuffer.
-3. **Verification:** Validates `content_manifest.json` SHA-256 hashes before processing. **Fail if mismatch.**.
+3. **Verification:** Validates `manifest.json` SHA-256 hashes before processing. **Fail if mismatch.**.
 4. **Processing:** `HtmlProcessingService` sanitizes HTML and handles asset injection.
 
 ### Pagination Logic (Critical Complexity)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ The viewer does **client-side pagination**. It does not use standard CSS print m
 - Forms are **not** standard Angular Reactive Forms.
 - We map JSON files from `wdoc-form/` in the zip to HTML `<input>` elements by `name` attribute.
 - **Saving:** When saving, we read the DOM values and write new JSON files back into the Zip buffer.
+- File inputs keep track of the previously saved attachment name; when a new file is uploaded, remove the old link and drop the
+  old file from the archive before hashing.
 
 ## 4. Coding Standards & Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@ The viewer injects specific custom elements. Do not remove these from sanitizati
 - `wdoc-header`, `wdoc-footer`
 - `wdoc-barcode` (rendered dynamically via service).
 
+### Manifest rules
+
+- Use the shared `APP_VERSION` constant (`src/app/config/app.config.ts`) when writing `manifest.json` and surface it under `meta.appVersion`.
+- Only set `meta.creator` when an authenticated user email is available; omit the field entirely otherwise.
+
 ## 5. Testing Guidelines
 
 ### Unit Tests (Jasmine)

--- a/src/app/config/app.config.ts
+++ b/src/app/config/app.config.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = '0.0.1';

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -69,6 +69,12 @@ describe('AuthService', () => {
     expect(supabaseStub.auth.signOut.calls.count()).toBe(1);
   });
 
+  it('returns stored email when no session is available', () => {
+    localStorage.setItem('wdoc-auth-email', 'remembered@example.com');
+    service = TestBed.inject(AuthService);
+
+    expect(service.getCurrentUserEmail()).toBe('remembered@example.com');
+  });
 
   it('updates stored email when auth state changes', fakeAsync(() => {
     service = TestBed.inject(AuthService);

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -53,7 +53,7 @@ export class AuthService {
   }
 
   getCurrentUserEmail(): string | null {
-    return this.sessionSubject.getValue()?.user?.email ?? null;
+    return this.sessionSubject.getValue()?.user?.email ?? this.getStoredEmail();
   }
 
   getStoredEmail(): string | null {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -52,6 +52,10 @@ export class AuthService {
     return this.supabase.auth.signOut();
   }
 
+  getCurrentUserEmail(): string | null {
+    return this.sessionSubject.getValue()?.user?.email ?? null;
+  }
+
   getStoredEmail(): string | null {
     if (typeof window === 'undefined') {
       return null;

--- a/src/app/services/document-creator.service.spec.ts
+++ b/src/app/services/document-creator.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import JSZip from 'jszip';
 import { DocumentCreatorService } from './document-creator.service';
+import { WdocManifest } from './manifest-builder';
 
 describe('DocumentCreatorService', () => {
   let service: DocumentCreatorService;
@@ -16,14 +17,16 @@ describe('DocumentCreatorService', () => {
     const zip = await JSZip.loadAsync(arrayBuffer);
 
     const index = zip.file('index.html');
-    const manifest = zip.file('content_manifest.json');
+    const manifest = zip.file('manifest.json');
 
     expect(index).toBeTruthy();
     expect(manifest).toBeTruthy();
 
-    const manifestJson = JSON.parse(await manifest!.async('text'));
-    const filePaths = manifestJson.files.map((f: any) => f.path);
-    expect(filePaths).toContain('index.html');
+    const manifestJson = JSON.parse(
+      await manifest!.async('text'),
+    ) as WdocManifest;
+    expect(manifestJson.content.files['index.html']).toBeDefined();
+    expect(manifestJson.content.hashAlgorithm).toBe('sha256');
   });
 
   it('scopes default styles to the document wrapper', async () => {
@@ -48,21 +51,20 @@ describe('DocumentCreatorService', () => {
     expect(revokeSpy).toHaveBeenCalledWith('blob:url');
   });
 
-  it('labels manifest entries with roles and mime types', async () => {
+  it('includes all document files in manifest content and runtime sections', async () => {
     const zip = new JSZip();
     zip.file('index.html', '<p>hello</p>');
     zip.folder('wdoc-form')?.file('form-1.json', '{}');
     zip.file('assets/image.png', 'data');
 
-    const manifest = await (service as any).generateContentManifest(zip);
-    const files = JSON.parse(manifest).files as Array<{ path: string; role: string; mime: string }>;
-    const roles = files.reduce<Record<string, string>>((acc, file) => {
-      acc[file.path] = file.role;
-      return acc;
-    }, {});
+    const manifestJson = JSON.parse(
+      await (service as any).generateManifest(zip),
+    ) as WdocManifest;
 
-    expect(roles['index.html']).toBe('doc_core');
-    expect(roles['wdoc-form/form-1.json']).toBe('form_instance');
-    expect(files.find((f) => f.path === 'assets/image.png')?.mime).toBe('image/png');
+    expect(manifestJson.content.files['index.html']).toBeDefined();
+    expect(manifestJson.content.files['assets/image.png']).toBeDefined();
+    expect(
+      manifestJson.runtime.forms['default'].files['wdoc-form/form-1.json'],
+    ).toBeDefined();
   });
 });

--- a/src/app/services/document-creator.service.ts
+++ b/src/app/services/document-creator.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import JSZip from 'jszip';
+import { APP_VERSION } from '../config/app.config';
+import { AuthService } from './auth.service';
 import {
   ManifestMetaOverrides,
   generateManifest,
@@ -8,6 +10,8 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class DocumentCreatorService {
+  constructor(private authService: AuthService) {}
+
   async downloadWdocFromHtml(html: string, filename = 'new-document.wdoc') {
     const blob = await this.buildWdocBlob(html);
     const link = document.createElement('a');
@@ -54,9 +58,11 @@ ${content}
   }
 
   private buildManifestMeta(): ManifestMetaOverrides {
+    const creator = this.authService.getCurrentUserEmail();
     return {
       docTitle: 'WDOC document',
-      creator: 'wdoc-webapp',
+      appVersion: APP_VERSION,
+      ...(creator ? { creator } : {}),
     };
   }
 }

--- a/src/app/services/form-manager.service.spec.ts
+++ b/src/app/services/form-manager.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import JSZip from 'jszip';
+import { APP_VERSION } from '../config/app.config';
+import { AuthService } from './auth.service';
 import { FormManagerService } from './form-manager.service';
 import { WdocLoaderService } from './wdoc-loader.service';
 
@@ -10,9 +12,17 @@ interface FormDriveEntry {
 
 describe('FormManagerService', () => {
   let service: FormManagerService;
+  let authService: jasmine.SpyObj<AuthService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    authService = jasmine.createSpyObj<AuthService>('AuthService', [
+      'getCurrentUserEmail',
+    ]);
+    authService.getCurrentUserEmail.and.returnValue('form@example.com');
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: AuthService, useValue: authService }],
+    });
     service = TestBed.inject(FormManagerService);
   });
 
@@ -155,6 +165,8 @@ describe('FormManagerService', () => {
     ) as any;
 
     expect(manifest.content.files['index.html']).toBeDefined();
+    expect(manifest.meta.appVersion).toBe(APP_VERSION);
+    expect(manifest.meta.creator).toBe('form@example.com');
     expect(
       manifest.runtime.forms.default.files['wdoc-form/form1.json'],
     ).toBeDefined();

--- a/src/app/services/form-manager.service.spec.ts
+++ b/src/app/services/form-manager.service.spec.ts
@@ -151,16 +151,14 @@ describe('FormManagerService', () => {
     expect(attachment).toBe('hello');
 
     const manifest = JSON.parse(
-      await savedZip.file('content_manifest.json')!.async('text'),
-    ) as { files: Array<{ path: string; role: string; mime: string }>; };
-    const roles = manifest.files.reduce<Record<string, string>>((acc, entry) => {
-      acc[entry.path] = entry.role;
-      return acc;
-    }, {});
+      await savedZip.file('manifest.json')!.async('text'),
+    ) as any;
 
-    expect(roles['index.html']).toBe('doc_core');
-    expect(roles['wdoc-form/form1.json']).toBe('form_instance');
-    expect(roles['wdoc-form/note.txt']).toBe('form_attachment');
+    expect(manifest.content.files['index.html']).toBeDefined();
+    expect(
+      manifest.runtime.forms.default.files['wdoc-form/form1.json'],
+    ).toBeDefined();
+    expect(manifest.runtime.forms.default.files['wdoc-form/note.txt']).toBeDefined();
   });
 
   it('blocks saving when HTML form validation fails', async () => {

--- a/src/app/services/manifest-builder.ts
+++ b/src/app/services/manifest-builder.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip';
+import { APP_VERSION } from '../config/app.config';
 import { WdocLoaderService } from './wdoc-loader.service';
 
 export interface ManifestSection {
@@ -11,8 +12,8 @@ export interface ManifestSection {
 export interface WdocManifest {
   meta: {
     docTitle: string;
-    creator: string;
-    appVersion?: string;
+    creator?: string;
+    appVersion: string;
     creationDate: string;
     lastUpdateDate: string;
   };
@@ -58,10 +59,12 @@ export async function generateManifest(
 
   const baseMeta = {
     docTitle: metaOverrides?.docTitle ?? 'WDOC document',
-    creator: metaOverrides?.creator ?? 'wdoc-webapp',
+    ...(metaOverrides?.creator ? { creator: metaOverrides.creator } : {}),
     creationDate: metaOverrides?.creationDate ?? now,
-    appVersion: metaOverrides?.appVersion,
-  } satisfies Omit<WdocManifest['meta'], 'lastUpdateDate'>;
+    appVersion: metaOverrides?.appVersion ?? APP_VERSION,
+  } satisfies Omit<WdocManifest['meta'], 'lastUpdateDate' | 'creator'> & {
+    creator?: string;
+  };
 
   return {
     meta: {

--- a/src/app/services/manifest-builder.ts
+++ b/src/app/services/manifest-builder.ts
@@ -1,0 +1,101 @@
+import JSZip from 'jszip';
+import { WdocLoaderService } from './wdoc-loader.service';
+
+export interface ManifestSection {
+  hashAlgorithm: 'sha256';
+  lastUpdateDate: string;
+  files: Record<string, string>;
+  contentDigest: string;
+}
+
+export interface WdocManifest {
+  meta: {
+    docTitle: string;
+    creator: string;
+    appVersion?: string;
+    creationDate: string;
+    lastUpdateDate: string;
+  };
+  content: ManifestSection;
+  runtime: {
+    forms: Record<string, ManifestSection>;
+  };
+}
+
+export interface ManifestMetaOverrides {
+  docTitle?: string;
+  creator?: string;
+  appVersion?: string;
+  creationDate?: string;
+}
+
+const TEXT_ENCODER = new TextEncoder();
+
+export async function generateManifest(
+  zip: JSZip,
+  metaOverrides?: ManifestMetaOverrides,
+): Promise<WdocManifest> {
+  const now = new Date().toISOString();
+
+  const contentFiles: Record<string, string> = {};
+  const runtimeFormFiles: Record<string, string> = {};
+
+  const entries = Object.values(zip.files);
+  for (const entry of entries) {
+    if (entry.dir || entry.name === 'manifest.json') {
+      continue;
+    }
+
+    const data = await entry.async('uint8array');
+    const hash = await WdocLoaderService.computeSha256(data);
+
+    if (entry.name.startsWith('wdoc-form/')) {
+      runtimeFormFiles[entry.name] = hash;
+    } else {
+      contentFiles[entry.name] = hash;
+    }
+  }
+
+  const baseMeta = {
+    docTitle: metaOverrides?.docTitle ?? 'WDOC document',
+    creator: metaOverrides?.creator ?? 'wdoc-webapp',
+    creationDate: metaOverrides?.creationDate ?? now,
+    appVersion: metaOverrides?.appVersion,
+  } satisfies Omit<WdocManifest['meta'], 'lastUpdateDate'>;
+
+  return {
+    meta: {
+      ...baseMeta,
+      lastUpdateDate: now,
+    },
+    content: await buildSection(contentFiles, now),
+    runtime: {
+      forms:
+        Object.keys(runtimeFormFiles).length > 0
+          ? { default: await buildSection(runtimeFormFiles, now) }
+          : {},
+    },
+  };
+}
+
+export function serializeManifest(manifest: WdocManifest): string {
+  return JSON.stringify(manifest, null, 2);
+}
+
+async function buildSection(
+  files: Record<string, string>,
+  lastUpdateDate: string,
+): Promise<ManifestSection> {
+  return {
+    hashAlgorithm: 'sha256',
+    lastUpdateDate,
+    files,
+    contentDigest: await computeDigest(files),
+  };
+}
+
+async function computeDigest(files: Record<string, string>): Promise<string> {
+  const sorted = Object.entries(files).sort(([a], [b]) => a.localeCompare(b));
+  const payload = sorted.map(([path, hash]) => `${path}:${hash}`).join('\n');
+  return WdocLoaderService.computeSha256(TEXT_ENCODER.encode(payload));
+}

--- a/src/app/services/wdoc-loader.service.spec.ts
+++ b/src/app/services/wdoc-loader.service.spec.ts
@@ -43,11 +43,21 @@ describe('WdocLoaderService', () => {
     const zip = new JSZip();
     zip.file('index.html', '<html></html>');
     zip.file(
-      'content_manifest.json',
+      'manifest.json',
       JSON.stringify({
-        version: '1.0',
-        algorithm: 'sha256',
-        files: [{ path: 'index.html', sha256: '0'.repeat(64) }],
+        meta: {
+          docTitle: 'Doc',
+          creator: 'tester',
+          creationDate: '2024-01-01T00:00:00Z',
+          lastUpdateDate: '2024-01-01T00:00:00Z',
+        },
+        content: {
+          hashAlgorithm: 'sha256',
+          lastUpdateDate: '2024-01-01T00:00:00Z',
+          files: { 'index.html': '0'.repeat(64) },
+          contentDigest: '0'.repeat(64),
+        },
+        runtime: { forms: {} },
       })
     );
     const ok = await (service as any).verifyContentManifest(zip);


### PR DESCRIPTION
## Summary
- add manifest builder to assemble meta, content, and runtime hash data into manifest.json
- update document creation, form saving, and loader verification to use the new manifest layout
- refresh guidance and tests to match manifest.json hashing

## Testing
- npm test -- --watch=false --progress=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929b2d70d80832b874903fff132e047)