### PR TITLE
Add document versioning support

### DIFF
--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -170,7 +170,24 @@ describe('AppComponent', () => {
     await app.onSaveNewDocument();
 
     expect(app.isEditing).toBeTrue();
-    expect(documentCreator.downloadWdocFromHtml).toHaveBeenCalled();
+    expect(documentCreator.downloadWdocFromHtml).toHaveBeenCalledWith(
+      jasmine.any(String),
+      '1.0.0',
+    );
+  });
+
+  it('bumps document version on each subsequent save', async () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+    app.startNewDocument();
+
+    await app.onSaveNewDocument();
+    await app.onSaveNewDocument();
+
+    expect(documentCreator.downloadWdocFromHtml).toHaveBeenCalledWith(
+      jasmine.any(String),
+      '2.0.0',
+    );
   });
 
   it('handles dragenter/leave to toggle overlay depth', () => {

--- a/src/app/app/app.component.ts
+++ b/src/app/app/app.component.ts
@@ -57,6 +57,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   documentTitle = this.defaultTitle;
   editorContent = '<p>Start writing...</p>';
   private originalArrayBuffer: ArrayBuffer | null = null;
+  private docVersionCounter = 0;
   private resizeListener?: () => void;
   private isDesktop = false;
   private beforePrintListener?: () => void;
@@ -379,6 +380,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     this.documentTitle = this.newDocumentTitle;
     this.editorContent = '<p>Start writing...</p>';
     this.showDocumentSave = true;
+    this.docVersionCounter = 0;
     this.cdr.markForCheck();
   }
 
@@ -391,7 +393,16 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     const content = this.editorContent?.trim()
       ? this.editorContent
       : '<p></p>';
-    await this.documentCreatorService.downloadWdocFromHtml(content);
+    const docVersion = this.buildNextDocVersion();
+    await this.documentCreatorService.downloadWdocFromHtml(
+      content,
+      docVersion,
+    );
     this.showDocumentSave = false;
+  }
+
+  private buildNextDocVersion(): string {
+    this.docVersionCounter += 1;
+    return `${this.docVersionCounter}.0.0`;
   }
 }

--- a/src/app/services/document-creator.service.spec.ts
+++ b/src/app/services/document-creator.service.spec.ts
@@ -22,7 +22,7 @@ describe('DocumentCreatorService', () => {
   });
 
   it('builds a wdoc blob with an index and manifest entries', async () => {
-    const blob = await service.buildWdocBlob('<p>Draft</p>');
+    const blob = await service.buildWdocBlob('<p>Draft</p>', '1.0.0');
     const arrayBuffer = await blob.arrayBuffer();
     const zip = await JSZip.loadAsync(arrayBuffer);
 
@@ -39,10 +39,11 @@ describe('DocumentCreatorService', () => {
     expect(manifestJson.content.hashAlgorithm).toBe('sha256');
     expect(manifestJson.meta.appVersion).toBe(APP_VERSION);
     expect(manifestJson.meta.creator).toBe('author@example.com');
+    expect(manifestJson.meta.docVersion).toBe('1.0.0');
   });
 
   it('scopes default styles to the document wrapper', async () => {
-    const blob = await service.buildWdocBlob('<p>Draft</p>');
+    const blob = await service.buildWdocBlob('<p>Draft</p>', '1.0.0');
     const zip = await JSZip.loadAsync(await blob.arrayBuffer());
     const indexContent = await zip.file('index.html')!.async('text');
 
@@ -56,7 +57,11 @@ describe('DocumentCreatorService', () => {
     const revokeSpy = spyOn(URL, 'revokeObjectURL');
     const clickSpy = spyOn(HTMLAnchorElement.prototype, 'click');
 
-    await service.downloadWdocFromHtml('<p>content</p>', 'custom-name.wdoc');
+    await service.downloadWdocFromHtml(
+      '<p>content</p>',
+      '2.0.0',
+      'custom-name.wdoc',
+    );
 
     expect(createObjectUrlSpy).toHaveBeenCalled();
     expect(clickSpy).toHaveBeenCalled();
@@ -70,7 +75,7 @@ describe('DocumentCreatorService', () => {
     zip.file('assets/image.png', 'data');
 
     const manifestJson = JSON.parse(
-      await (service as any).generateManifest(zip),
+      await (service as any).generateManifest(zip, '1.0.0'),
     ) as WdocManifest;
 
     expect(manifestJson.content.files['index.html']).toBeDefined();
@@ -83,7 +88,7 @@ describe('DocumentCreatorService', () => {
   it('omits creator when no user session is available', async () => {
     authService.getCurrentUserEmail.and.returnValue(null);
 
-    const blob = await service.buildWdocBlob('<p>Draft</p>');
+    const blob = await service.buildWdocBlob('<p>Draft</p>', '1.0.0');
     const zip = await JSZip.loadAsync(await blob.arrayBuffer());
     const manifestJson = JSON.parse(
       await zip.file('manifest.json')!.async('text'),
@@ -91,5 +96,6 @@ describe('DocumentCreatorService', () => {
 
     expect(manifestJson.meta.creator).toBeUndefined();
     expect(manifestJson.meta.appVersion).toBe(APP_VERSION);
+    expect(manifestJson.meta.docVersion).toBe('1.0.0');
   });
 });

--- a/src/app/services/form-manager.service.spec.ts
+++ b/src/app/services/form-manager.service.spec.ts
@@ -197,6 +197,7 @@ describe('FormManagerService', () => {
     expect(manifest.content.files['index.html']).toBeDefined();
     expect(manifest.meta.appVersion).toBe(APP_VERSION);
     expect(manifest.meta.creator).toBe('form@example.com');
+    expect(manifest.meta.docVersion).toBe('1.0.0');
     expect(
       manifest.runtime.forms.default.files['wdoc-form/form1.json'],
     ).toBeDefined();

--- a/src/app/services/form-manager.service.ts
+++ b/src/app/services/form-manager.service.ts
@@ -208,6 +208,7 @@ export class FormManagerService {
         creator: parsed.meta?.creator,
         appVersion: parsed.meta?.appVersion,
         creationDate: parsed.meta?.creationDate,
+        docVersion: parsed.meta?.docVersion,
       } satisfies ManifestMetaOverrides;
     } catch {
       return {};

--- a/src/app/services/manifest-builder.ts
+++ b/src/app/services/manifest-builder.ts
@@ -16,6 +16,7 @@ export interface WdocManifest {
     appVersion: string;
     creationDate: string;
     lastUpdateDate: string;
+    docVersion: string;
   };
   content: ManifestSection;
   runtime: {
@@ -28,6 +29,7 @@ export interface ManifestMetaOverrides {
   creator?: string;
   appVersion?: string;
   creationDate?: string;
+  docVersion?: string;
 }
 
 const TEXT_ENCODER = new TextEncoder();
@@ -62,6 +64,7 @@ export async function generateManifest(
     ...(metaOverrides?.creator ? { creator: metaOverrides.creator } : {}),
     creationDate: metaOverrides?.creationDate ?? now,
     appVersion: metaOverrides?.appVersion ?? APP_VERSION,
+    docVersion: metaOverrides?.docVersion ?? '1.0.0',
   } satisfies Omit<WdocManifest['meta'], 'lastUpdateDate' | 'creator'> & {
     creator?: string;
   };


### PR DESCRIPTION
## Summary
- add `docVersion` metadata to generated manifests and preserve existing values when saving forms
- require the WYSIWYG editor saves to include a version string that increments on each save
- update related specs to cover version propagation in manifests and save flows

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless --progress=false *(fails: ChromeHeadless requires --no-sandbox in root environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692febe5bc40832bad534b84d7593842)