### PR TITLE
Add editable document titles and update downloads

### DIFF
--- a/src/app/app/app.component.html
+++ b/src/app/app/app.component.html
@@ -21,6 +21,7 @@
         [showDocumentSave]="isEditing && showDocumentSave"
         [navOpen]="isNavOpen"
         [title]="documentTitle"
+        [isEditing]="isEditing"
         [zoom]="zoom"
         [hasDocument]="!isEditing && !!htmlContent"
         [attachments]="attachments"
@@ -28,6 +29,8 @@
         (toggleNav)="toggleNav()"
         (saveForm)="onSaveForms()"
         (saveDocument)="onSaveNewDocument()"
+        (editDocument)="startEditingLoadedDocument()"
+        (titleChange)="onDocumentTitleChange($event)"
         (zoomChange)="onZoomChange($event)"
       ></app-topbar>
       @if (isEditing) {

--- a/src/app/app/app.component.spec.ts
+++ b/src/app/app/app.component.spec.ts
@@ -173,7 +173,50 @@ describe('AppComponent', () => {
     expect(documentCreator.downloadWdocFromHtml).toHaveBeenCalledWith(
       jasmine.any(String),
       '1.0.0',
+      'New document',
+      'new-document.wdoc',
     );
+  });
+
+  it('normalizes an empty title and marks the document dirty while editing', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+    app.isEditing = true;
+    app.onDocumentTitleChange('   ');
+
+    expect(app.documentTitle).toBe('New document');
+    expect(app.showDocumentSave).toBeTrue();
+    expect(document.title).toBe('New document');
+  });
+
+  it('extracts editor content from wdoc pages', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+    const html = `<!doctype html>
+      <html><body>
+        <wdoc-container>
+          <wdoc-page><wdoc-content><p>First</p></wdoc-content></wdoc-page>
+          <wdoc-page><wdoc-content><p>Second</p></wdoc-content></wdoc-page>
+        </wdoc-container>
+      </body></html>`;
+
+    const content = app['extractEditorContent'](html);
+
+    expect(content).toContain('First');
+    expect(content).toContain('Second');
+  });
+
+  it('enters editing mode with previously loaded content', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance as any;
+    app['loadedDocumentHtml'] = '<wdoc-container><wdoc-content><p>Loaded</p></wdoc-content></wdoc-container>';
+    app['editableContentFromLoaded'] = '<p>Loaded</p>';
+
+    app.startEditingLoadedDocument();
+
+    expect(app.isEditing).toBeTrue();
+    expect(app.editorContent).toContain('Loaded');
+    expect(app.showDocumentSave).toBeTrue();
   });
 
   it('bumps document version on each subsequent save', async () => {
@@ -187,6 +230,8 @@ describe('AppComponent', () => {
     expect(documentCreator.downloadWdocFromHtml).toHaveBeenCalledWith(
       jasmine.any(String),
       '2.0.0',
+      'New document',
+      'new-document.wdoc',
     );
   });
 

--- a/src/app/services/document-creator.service.ts
+++ b/src/app/services/document-creator.service.ts
@@ -15,33 +15,41 @@ export class DocumentCreatorService {
   async downloadWdocFromHtml(
     html: string,
     docVersion: string,
-    filename = 'new-document.wdoc',
+    docTitle: string,
+    filename?: string,
   ) {
-    const blob = await this.buildWdocBlob(html, docVersion);
+    const normalizedTitle = docTitle?.trim() || 'WDOC document';
+    const resolvedFilename =
+      filename ?? `${this.buildFilenameFromTitle(normalizedTitle)}.wdoc`;
+    const blob = await this.buildWdocBlob(html, docVersion, normalizedTitle);
     const link = document.createElement('a');
     link.href = URL.createObjectURL(blob);
-    link.download = filename;
+    link.download = resolvedFilename;
     link.click();
     URL.revokeObjectURL(link.href);
   }
 
-  async buildWdocBlob(html: string, docVersion: string): Promise<Blob> {
+  async buildWdocBlob(
+    html: string,
+    docVersion: string,
+    docTitle: string,
+  ): Promise<Blob> {
     const zip = new JSZip();
-    const wrapped = this.wrapHtml(html);
+    const wrapped = this.wrapHtml(html, docTitle);
     zip.file('index.html', wrapped);
     zip.folder('wdoc-form');
-    const manifest = await this.generateManifest(zip, docVersion);
+    const manifest = await this.generateManifest(zip, docVersion, docTitle);
     zip.file('manifest.json', manifest);
     return zip.generateAsync({ type: 'blob' });
   }
 
-  private wrapHtml(content: string): string {
+  private wrapHtml(content: string, title: string): string {
     return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>WDOC document</title>
+  <title>${this.escapeHtml(title)}</title>
   <style>
     .wdoc-document { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; margin: 32px; line-height: 1.6; }
     .wdoc-document h1, .wdoc-document h2, .wdoc-document h3, .wdoc-document h4 { margin-top: 1.6em; }
@@ -56,18 +64,56 @@ ${content}
 </html>`;
   }
 
-  private async generateManifest(zip: JSZip, docVersion: string): Promise<string> {
-    const manifest = await generateManifest(zip, this.buildManifestMeta(docVersion));
+  private async generateManifest(
+    zip: JSZip,
+    docVersion: string,
+    docTitle: string,
+  ): Promise<string> {
+    const manifest = await generateManifest(
+      zip,
+      this.buildManifestMeta(docVersion, docTitle),
+    );
     return serializeManifest(manifest);
   }
 
-  private buildManifestMeta(docVersion: string): ManifestMetaOverrides {
+  private buildManifestMeta(
+    docVersion: string,
+    docTitle: string,
+  ): ManifestMetaOverrides {
     const creator = this.authService.getCurrentUserEmail();
     return {
-      docTitle: 'WDOC document',
+      docTitle: docTitle?.trim() || 'WDOC document',
       appVersion: APP_VERSION,
       docVersion,
       ...(creator ? { creator } : {}),
     };
+  }
+
+  private escapeHtml(text: string): string {
+    return text.replace(/[&<>"']/g, (char) => {
+      switch (char) {
+        case '&':
+          return '&amp;';
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt;';
+        case '"':
+          return '&quot;';
+        case "'":
+          return '&#39;';
+        default:
+          return char;
+      }
+    });
+  }
+
+  private buildFilenameFromTitle(title: string): string {
+    const safeTitle = title.trim() || 'document';
+    const slug = safeTitle
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gi, '-')
+      .replace(/^-+|-+$/g, '');
+    return slug || 'document';
   }
 }

--- a/src/app/topbar/topbar.component.css
+++ b/src/app/topbar/topbar.component.css
@@ -31,6 +31,23 @@
 .topbar-title {
   font-weight: 600;
   font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+}
+
+.title-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 360px;
+}
+
+.title-input {
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  font-size: 1rem;
+  min-width: 220px;
 }
 
 .topbar-actions {
@@ -165,6 +182,27 @@
   border-radius: 4px;
   cursor: pointer;
   font-weight: 600;
+}
+
+.topbar-secondary {
+  background: #ffffff;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 @media print {

--- a/src/app/topbar/topbar.component.html
+++ b/src/app/topbar/topbar.component.html
@@ -10,7 +10,23 @@
     <span></span>
     <span></span>
   </button>
-  <div class="topbar-title" [attr.title]="title">{{ title }}</div>
+  <div class="topbar-title">
+    @if (isEditing) {
+      <label class="visually-hidden" for="document-title-input">
+        Document title
+      </label>
+      <input
+        id="document-title-input"
+        type="text"
+        class="title-input"
+        [value]="title"
+        (input)="onTitleChange($event)"
+        placeholder="Untitled document"
+      />
+    } @else {
+      <div class="title-text" [attr.title]="title">{{ title }}</div>
+    }
+  </div>
   <div class="topbar-actions">
     @if (hasDocument) {
       <div class="zoom-controls" aria-label="Zoom controls">
@@ -98,13 +114,20 @@
     >
       Save form
     </button>
-    <button
-      class="topbar-save"
-      type="button"
-      (click)="onSaveDocument()"
-      [hidden]="!showDocumentSave"
-    >
-      Save document
-    </button>
+    @if (!isEditing && hasDocument) {
+      <button class="topbar-secondary" type="button" (click)="onEditDocument()">
+        Update document
+      </button>
+    }
+    @if (isEditing) {
+      <button
+        class="topbar-save"
+        type="button"
+        (click)="onSaveDocument()"
+        [hidden]="!showDocumentSave"
+      >
+        Save document
+      </button>
+    }
   </div>
 </header>

--- a/src/app/topbar/topbar.component.spec.ts
+++ b/src/app/topbar/topbar.component.spec.ts
@@ -33,6 +33,7 @@ describe('TopbarComponent', () => {
 
   it('emits save document when save document button clicked', () => {
     component.showDocumentSave = true;
+    component.isEditing = true;
     fixture.detectChanges();
     spyOn(component.saveDocument, 'emit');
     const buttons = fixture.nativeElement.querySelectorAll(
@@ -52,6 +53,31 @@ describe('TopbarComponent', () => {
       '.topbar-title'
     );
     expect(el.textContent?.trim()).toBe('My Document');
+  });
+
+  it('emits title changes when editing', () => {
+    component.isEditing = true;
+    fixture.detectChanges();
+    spyOn(component.titleChange, 'emit');
+    const input: HTMLInputElement = fixture.nativeElement.querySelector(
+      '#document-title-input',
+    );
+    input.value = 'Updated title';
+    input.dispatchEvent(new Event('input'));
+
+    expect(component.titleChange.emit).toHaveBeenCalledWith('Updated title');
+  });
+
+  it('emits editDocument when clicking update button', () => {
+    component.hasDocument = true;
+    fixture.detectChanges();
+    spyOn(component.editDocument, 'emit');
+    const updateButton: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '.topbar-secondary',
+    );
+    updateButton.click();
+
+    expect(component.editDocument.emit).toHaveBeenCalled();
   });
 
   it('emits zoomChange when zoom buttons are used', () => {

--- a/src/app/topbar/topbar.component.ts
+++ b/src/app/topbar/topbar.component.ts
@@ -21,6 +21,7 @@ export class TopbarComponent implements OnChanges {
   @Input() showDocumentSave = false;
   @Input() navOpen = false;
   @Input() title = 'WDOC viewer';
+  @Input() isEditing = false;
   @Input() zoom = 100;
   @Input() hasDocument = false;
   @Input() attachments: LoadedFile[] = [];
@@ -28,6 +29,8 @@ export class TopbarComponent implements OnChanges {
   @Output() toggleNav = new EventEmitter<void>();
   @Output() saveForm = new EventEmitter<void>();
   @Output() saveDocument = new EventEmitter<void>();
+  @Output() editDocument = new EventEmitter<void>();
+  @Output() titleChange = new EventEmitter<string>();
   @Output() zoomChange = new EventEmitter<number>();
   zoomValue = '100';
   attachmentsMenuOpen = false;
@@ -79,6 +82,15 @@ export class TopbarComponent implements OnChanges {
       return;
     }
     this.attachmentsMenuOpen = !this.attachmentsMenuOpen;
+  }
+
+  onEditDocument(): void {
+    this.editDocument.emit();
+  }
+
+  onTitleChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.titleChange.emit(value);
   }
 
   downloadFile(file: LoadedFile): void {


### PR DESCRIPTION
## Summary
- add editable title input and update button in the top bar when working with documents
- allow switching loaded documents into the editor and propagate title updates through the app
- include the document title in generated archives for head, manifest, and download filenames

## Testing
- CI=true npm test -- --watch=false --progress=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69306468e0f0832bac096a88313ff67d)