### PR TITLE
Close auth modals when logging out

### DIFF
--- a/src/app/navbar/navbar.component.css
+++ b/src/app/navbar/navbar.component.css
@@ -165,6 +165,12 @@
   gap: 0.5rem;
 }
 
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .input-label {
   font-weight: 600;
 }
@@ -175,6 +181,8 @@
   border: 1px solid #cbd5e1;
   border-radius: 4px;
   font-size: 1rem;
+  box-sizing: border-box;
+  max-width: 100%;
 }
 
 .status-message {

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -45,35 +45,34 @@
       </div>
       <div class="modal-body">
         <ng-container *ngIf="!emailSent; else emailSentTemplate">
-          <label class="input-label" for="auth-email">Email address</label>
-          <input
-            id="auth-email"
-            name="email"
-            type="email"
-            [(ngModel)]="email"
-            class="modal-input"
-            placeholder="you@example.com"
-            required
-          />
-          <p class="status-message" *ngIf="statusMessage">{{ statusMessage }}</p>
+          <form class="auth-form" (ngSubmit)="onAuthSubmit()">
+            <label class="input-label" for="auth-email">Email address</label>
+            <input
+              id="auth-email"
+              name="email"
+              type="email"
+              [(ngModel)]="email"
+              class="modal-input"
+              placeholder="you@example.com"
+              required
+            />
+            <p class="status-message" *ngIf="statusMessage">{{ statusMessage }}</p>
+            <div class="modal-actions">
+              <button
+                type="submit"
+                class="nav-btn full-width primary"
+                [disabled]="isSubmitting"
+              >
+                {{ isSubmitting ? 'Sending...' : 'Send login link' }}
+              </button>
+            </div>
+            <p class="hint">We will send a login or signup link to your email.</p>
+          </form>
         </ng-container>
         <ng-template #emailSentTemplate>
           <p class="status-message">{{ statusMessage }}</p>
         </ng-template>
       </div>
-      <div class="modal-actions" *ngIf="!emailSent">
-        <button
-          type="button"
-          class="nav-btn full-width"
-          (click)="onAuthSubmit()"
-          [disabled]="isSubmitting"
-        >
-          {{ isSubmitting ? 'Sending...' : 'Send login link' }}
-        </button>
-      </div>
-      <p class="hint" *ngIf="!emailSent">
-        We will send a login or signup link to your email.
-      </p>
     </div>
   </div>
 

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -43,6 +43,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.currentUserEmail = this.authService.getStoredEmail();
     this.sessionSub = this.authService.session$.subscribe((session) => {
       this.currentUserEmail = session?.user?.email ?? this.authService.getStoredEmail();
+      if (!session) {
+        this.resetAuthUiState();
+      }
     });
   }
 
@@ -98,17 +101,18 @@ export class NavbarComponent implements OnInit, OnDestroy {
       this.statusMessage = 'Please enter your email to continue.';
       return;
     }
+    this.emailSent = true;
     this.isSubmitting = true;
-    this.statusMessage = '';
+    this.statusMessage = 'Sending...';
     const { error } = await this.authService.signInWithEmail(this.email);
     this.isSubmitting = false;
     if (error) {
       this.statusMessage = error.message;
+      this.emailSent = false;
       return;
     }
     this.currentUserEmail = this.email;
     this.statusMessage = 'Please check your email.';
-    this.emailSent = true;
   }
 
   async onLogout() {
@@ -116,8 +120,15 @@ export class NavbarComponent implements OnInit, OnDestroy {
     await this.authService.signOut();
     this.isSubmitting = false;
     this.currentUserEmail = null;
+    this.resetAuthUiState();
+  }
+
+  private resetAuthUiState() {
+    this.isSettingsModalOpen = false;
+    this.isAuthModalOpen = false;
+    this.emailSent = false;
     this.statusMessage = '';
     this.email = '';
-    this.isSettingsModalOpen = false;
+    this.isSubmitting = false;
   }
 }


### PR DESCRIPTION
## Summary
- Reset auth modal state when the session ends or the user logs out to ensure popups close
- Centralize auth UI reset logic so logout returns the interface to an unauthenticated state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6933f8cb455c832b8dcf9ea31c997a5b)